### PR TITLE
Add folder thumbnail previews and pagination to Image Repository

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1295,9 +1295,26 @@ async def browse_image_repo(path: str = ""):
             if item.is_dir():
                 # Get relative path from repo root
                 rel_path = item.relative_to(repo_root_path)
+
+                # Get up to 3 preview images from the folder
+                preview_images = []
+                try:
+                    for img_file in sorted(item.iterdir()):
+                        # Skip hidden files and non-image files
+                        if img_file.name.startswith('.'):
+                            continue
+                        if img_file.is_file() and img_file.suffix.lower() in ['.jpg', '.jpeg', '.png']:
+                            img_rel = img_file.relative_to(repo_root_path)
+                            preview_images.append(str(img_rel).replace("\\", "/"))
+                            if len(preview_images) >= 3:
+                                break
+                except (PermissionError, OSError):
+                    pass  # Skip folders we can't read
+
                 folders.append({
                     "name": item.name,
-                    "path": str(rel_path).replace("\\", "/")  # Normalize path separators
+                    "path": str(rel_path).replace("\\", "/"),  # Normalize path separators
+                    "preview_images": preview_images
                 })
             elif item.is_file():
                 # Only include jpg and png files

--- a/react-app/src/pages/ImageRepo.css
+++ b/react-app/src/pages/ImageRepo.css
@@ -81,6 +81,72 @@
   object-fit: contain;
 }
 
+/* Folder preview with collage */
+.folder-preview {
+  position: relative;
+}
+
+.folder-collage {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  gap: 2px;
+}
+
+.folder-collage img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  max-width: none;
+  max-height: none;
+}
+
+/* Single image - full size */
+.collage-1 {
+  grid-template-columns: 1fr;
+}
+
+/* Two images - side by side */
+.collage-2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+/* Three images - one large left, two stacked right */
+.collage-3 {
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+
+.collage-3 img:first-child {
+  grid-row: span 2;
+}
+
+/* Empty folder fallback */
+.folder-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 48px;
+  background: #f5f5f5;
+}
+
+/* Hidden fallback - shows when all images fail */
+.folder-fallback {
+  display: none;
+  position: absolute;
+  inset: 0;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  background: #f5f5f5;
+}
+
+.folder-collage.all-failed .folder-fallback {
+  display: flex;
+}
+
 .repo-item-name {
   font-size: 13px;
   color: #333;


### PR DESCRIPTION
- Display image collage (up to 3 images) as folder thumbnails in grid view
- Add pagination for folders on root level (24 per page)
- Skip hidden files when scanning for preview images
- Graceful fallback to folder icon if images are missing/deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)