### PR TITLE
Fixed seed per job and improved backend restart recovery

### DIFF
--- a/backend/comfyui_client.py
+++ b/backend/comfyui_client.py
@@ -323,9 +323,10 @@ class ComfyUIClient:
 
         workflow = copy.deepcopy(WORKFLOW_TEMPLATES[workflow_type])
 
-        # Set seed
+        # Set seed (fallback - normally provided by job)
         if seed is None:
-            seed = random.randint(0, 2**32 - 1)
+            from database import generate_seed
+            seed = generate_seed()
 
         # Update common parameters
         if "3" in workflow:  # KSampler node

--- a/backend/workflow_templates.py
+++ b/backend/workflow_templates.py
@@ -242,9 +242,10 @@ def build_wan_i2v_workflow(
     # Deep copy the template so we don't modify the original
     workflow = copy.deepcopy(WAN_I2V_API_WORKFLOW)
 
-    # Generate seed if not provided
+    # Generate seed if not provided (fallback - normally provided by job)
     if seed is None:
-        seed = random.randint(0, 2**32 - 1)
+        from database import generate_seed
+        seed = generate_seed()
 
     # Override start image filename (node 97 - LoadImage)
     workflow["97"]["inputs"]["image"] = start_image_filename

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -344,6 +344,12 @@ export default function JobDetail() {
             <div className="value">{fps} fps</div>
           </div>
           <div className="detail-meta-item">
+            <label>Seed</label>
+            <div className="value" style={{ fontFamily: 'monospace', fontSize: '12px' }}>
+              {job.seed ?? 'N/A'}
+            </div>
+          </div>
+          <div className="detail-meta-item">
             <label>Face Swap</label>
             <div className="value">
               {params.faceswap_enabled


### PR DESCRIPTION
- Add seed column to jobs table with auto-generation (0 to 2^63-1)
- Same seed used for all segments in a job for consistency
- Display seed in Job Details UI with monospace formatting
- Fix backend restart: detect prompts still running in ComfyUI queue
- Resume monitoring running segments instead of resetting to pending
- Add background thread to continue waiting for segment completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)