### PR TITLE
Add default high/low weights per LoRA in library

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -273,6 +273,8 @@ class LoraUpdate(BaseModel):
     notes: Optional[str] = None
     preview_image_url: Optional[str] = None
     fetch_preview: Optional[bool] = False  # If true, auto-fetch preview from URL
+    default_high_weight: Optional[float] = None
+    default_low_weight: Optional[float] = None
 
 
 def enrich_job_with_segments(job: Dict[str, Any]) -> Dict[str, Any]:
@@ -1048,7 +1050,9 @@ async def update_lora(lora_id: int, lora_data: LoraUpdate):
         trigger_keywords=lora_data.trigger_keywords,
         rating=lora_data.rating,
         notes=lora_data.notes,
-        preview_image_url=preview_url
+        preview_image_url=preview_url,
+        default_high_weight=lora_data.default_high_weight,
+        default_low_weight=lora_data.default_low_weight
     )
 
     # Return updated LoRA

--- a/react-app/src/components/CreateJobModal.jsx
+++ b/react-app/src/components/CreateJobModal.jsx
@@ -484,7 +484,11 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
                   label=""
                   value={selectedLoras[0].lora}
                   onChange={(lora) => setSelectedLoras([
-                    { ...selectedLoras[0], lora },
+                    {
+                      lora,
+                      highWeight: lora?.default_high_weight ?? 1,
+                      lowWeight: lora?.default_low_weight ?? 1
+                    },
                     selectedLoras[1]
                   ])}
                   loras={loras}
@@ -529,7 +533,11 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
                   value={selectedLoras[1].lora}
                   onChange={(lora) => setSelectedLoras([
                     selectedLoras[0],
-                    { ...selectedLoras[1], lora }
+                    {
+                      lora,
+                      highWeight: lora?.default_high_weight ?? 1,
+                      lowWeight: lora?.default_low_weight ?? 1
+                    }
                   ])}
                   loras={loras}
                 />

--- a/react-app/src/components/LoraEditModal.jsx
+++ b/react-app/src/components/LoraEditModal.jsx
@@ -17,6 +17,8 @@ export default function LoraEditModal({ lora, onClose, onSave }) {
   const [triggerKeywords, setTriggerKeywords] = useState(lora.trigger_keywords || '');
   const [rating, setRating] = useState(lora.rating || null);
   const [notes, setNotes] = useState(lora.notes || '');
+  const [defaultHighWeight, setDefaultHighWeight] = useState(lora.default_high_weight ?? 1.0);
+  const [defaultLowWeight, setDefaultLowWeight] = useState(lora.default_low_weight ?? 1.0);
   const [hasPreview, setHasPreview] = useState(!!lora.preview_image_url);
   const [previewCacheBust, setPreviewCacheBust] = useState(Date.now());
   const [saving, setSaving] = useState(false);
@@ -56,7 +58,9 @@ export default function LoraEditModal({ lora, onClose, onSave }) {
         prompt_text: promptText || null,
         trigger_keywords: triggerKeywords || null,
         rating: rating,
-        notes: notes || null
+        notes: notes || null,
+        default_high_weight: defaultHighWeight,
+        default_low_weight: defaultLowWeight
         // preview_image_url is managed by the refresh-preview endpoint
       });
 
@@ -90,6 +94,29 @@ export default function LoraEditModal({ lora, onClose, onSave }) {
               <code>{lora.low_file ? lora.low_file.split('/').pop() : '—'}</code>
             </div>
           </div>
+          <div style={{ display: 'flex', gap: '12px', marginTop: '12px', paddingTop: '12px', borderTop: '1px solid #ddd' }}>
+            <TextField
+              type="number"
+              label="Default High Weight"
+              size="small"
+              value={defaultHighWeight}
+              onChange={(e) => setDefaultHighWeight(parseFloat(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 2, step: 0.1 }}
+              sx={{ width: '140px' }}
+            />
+            <TextField
+              type="number"
+              label="Default Low Weight"
+              size="small"
+              value={defaultLowWeight}
+              onChange={(e) => setDefaultLowWeight(parseFloat(e.target.value) || 0)}
+              inputProps={{ min: 0, max: 2, step: 0.1 }}
+              sx={{ width: '140px' }}
+            />
+          </div>
+          <Typography variant="caption" display="block" sx={{ mt: 1, color: '#666' }}>
+            Default weights to populate when this LoRA is selected in Create Job
+          </Typography>
         </div>
 
         <form onSubmit={handleSubmit}>


### PR DESCRIPTION
- Add default_high_weight and default_low_weight columns to lora_library
- Update LoraEditModal to show/edit default weight fields
- Update LoraUpdate Pydantic model and API endpoint
- CreateJobModal now populates weight fields from LoRA defaults when selected

Users can set per-LoRA default weights that auto-populate in the Create Job modal, reducing repetitive weight entry for LoRAs with known optimal settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)