### PR TITLE
Fix segment 0 resubmission and improve empty segments UI

### DIFF
--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -586,18 +586,22 @@ export default function JobDetail() {
               <Button
                 variant="contained"
                 onClick={() => setShowPromptModal(true)}
-                style={{ flex: 1 }}
+                style={{ flex: lastCompletedSegment ? 1 : 'none' }}
               >
-                Continue with Next Segment
+                {lastCompletedSegment ? 'Continue with Next Segment' : 'Submit First Segment'}
               </Button>
-              <div style={{ color: '#666', fontWeight: 500 }}>OR</div>
-              <Button
-                variant="contained"
-                onClick={handleFinalizeJob}
-                sx={{ flex: 1, bgcolor: '#4caf50', '&:hover': { bgcolor: '#388e3c' } }}
-              >
-                Finalize & Merge
-              </Button>
+              {lastCompletedSegment && (
+                <>
+                  <div style={{ color: '#666', fontWeight: 500 }}>OR</div>
+                  <Button
+                    variant="contained"
+                    onClick={handleFinalizeJob}
+                    sx={{ flex: 1, bgcolor: '#4caf50', '&:hover': { bgcolor: '#388e3c' } }}
+                  >
+                    Finalize & Merge
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
Three fixes:

1. When segment 0 was deleted and resubmitted, the code used the raw input_image filename instead of building a proper ComfyUI URL. Now builds the full URL, matching initial job creation behavior.

2. Remove legacy fallback that created fake segment stub data when no segments exist. This caused deleted segments to still appear in the UI. Now returns empty array, which the frontend handles correctly with "No segments yet" message.

3. Hide "Finalize & Merge" button when no completed segments exist. Change button text to "Submit First Segment" in this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)