### PR TITLE
Add mixed case patterns for LoRA grouping

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1149,6 +1149,7 @@ def _get_lora_base_and_type(filename: str) -> tuple:
         r'_high_',
         r'-high-',
         r'_high\.',
+        r'_High\.',  # Mixed case variant
     ]
 
     # Patterns for LOW variants
@@ -1165,6 +1166,7 @@ def _get_lora_base_and_type(filename: str) -> tuple:
         r'_low_',
         r'-low-',
         r'_low\.',
+        r'_Low\.',  # Mixed case variant
         r'[_-][Ll]ow[_-]',
     ]
 


### PR DESCRIPTION
- Add _High. and _Low. patterns to match files like Wan22_ThroatV3_High.safetensors
- Previously only _HIGH. _high. _LOW. _low. were matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)