### PR TITLE
Add job history side panel to Image Repository modal

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -396,6 +396,25 @@ def get_pending_jobs() -> List[Dict[str, Any]]:
         return [_row_to_job_dict(row) for row in cursor.fetchall()]
 
 
+def get_jobs_by_input_image(image_filename: str) -> List[Dict[str, Any]]:
+    """Get all jobs that used a specific image as input.
+
+    Matches jobs where input_image contains the filename (handles path variations).
+    Returns jobs ordered by creation date descending.
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        # Match by filename at the end of path or exact match
+        cursor.execute(
+            """SELECT id, name, status, created_at, completed_at
+               FROM jobs
+               WHERE input_image LIKE ? OR input_image = ?
+               ORDER BY created_at DESC""",
+            (f'%{image_filename}', image_filename)
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
 def move_job_up(job_id: int) -> bool:
     """Move a job up in the queue (decrease priority number to run sooner).
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -48,6 +48,7 @@ from database import (
     hide_lora_file,
     unhide_lora_file,
     get_hidden_loras as db_get_hidden_loras,
+    get_jobs_by_input_image,
     get_job_logs as db_get_job_logs
 )
 from comfyui_client import ComfyUIClient
@@ -1554,3 +1555,16 @@ async def set_image_rating_endpoint(image_path: str = Form(...), rating: Optiona
 
     set_image_rating(image_path, rating)
     return {"image_path": image_path, "rating": rating, "success": True}
+
+
+@router.get("/image-repo/jobs")
+async def get_jobs_for_image(filename: str):
+    """Get all jobs that used this image as input.
+
+    Returns a list of jobs with id, name, status, and dates.
+    """
+    if not filename:
+        raise HTTPException(status_code=400, detail="Filename is required")
+
+    jobs = get_jobs_by_input_image(filename)
+    return {"jobs": jobs}

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.3.6",
         "@mui/material": "^7.3.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1165,6 +1166,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.6.tgz",
+      "integrity": "sha512-0FfkXEj22ysIq5pa41A2NbcAhJSvmcZQ/vcTIbjDsd6hlslG82k5BEBqqS0ZJprxwIL3B45qpJ+bPHwJPlF7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.6",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -307,6 +307,10 @@ class APIClient {
     });
   }
 
+  async getJobsForImage(filename) {
+    return this.request(`/image-repo/jobs?filename=${encodeURIComponent(filename)}`);
+  }
+
   // ============== ComfyUI View Proxy ==============
 
   getComfyUIImage(filename, subfolder = '', type = 'input') {


### PR DESCRIPTION
Show list of jobs that used the selected image in a side panel:
- Added database function to query jobs by input image filename
- Added API endpoint GET /image-repo/jobs?filename=
- Added side panel to ImagePreviewModal with clickable job links
- Jobs link directly to job detail page

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)