### PR TITLE
Per-segment faceswap instead of job-level (#65)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -180,6 +180,24 @@ def init_db():
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+        # Add faceswap columns for per-segment faceswap settings
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN faceswap_enabled INTEGER DEFAULT 0")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN faceswap_image TEXT")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN faceswap_faces_order TEXT DEFAULT 'left-right'")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN faceswap_faces_index TEXT DEFAULT '0'")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
         # Add priority column for queue ordering (lower number = higher priority)
         try:
             cursor.execute("ALTER TABLE jobs ADD COLUMN priority INTEGER DEFAULT 0")
@@ -884,7 +902,11 @@ def create_first_segment(
     initial_prompt: str,
     start_image_url: str,
     high_loras: Optional[List[str]] = None,
-    low_loras: Optional[List[str]] = None
+    low_loras: Optional[List[str]] = None,
+    faceswap_enabled: bool = False,
+    faceswap_image: Optional[str] = None,
+    faceswap_faces_order: str = "left-right",
+    faceswap_faces_index: str = "0"
 ):
     """Create the first segment for a job (on-demand workflow).
 
@@ -897,14 +919,20 @@ def create_first_segment(
         start_image_url: ComfyUI image URL for the starting image
         high_loras: List of high noise LoRA filenames (max 2)
         low_loras: List of low noise LoRA filenames (max 2)
+        faceswap_enabled: Whether to enable face swapping for this segment
+        faceswap_image: Filename of the face image to swap in
+        faceswap_faces_order: Order to process faces (left-right, right-left, etc.)
+        faceswap_faces_index: Which face indices to process (e.g., "0", "0,1")
     """
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
-            INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?)
+            INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora,
+                                      faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, 0, initial_prompt, start_image_url,
-              serialize_loras(high_loras), serialize_loras(low_loras)))
+              serialize_loras(high_loras), serialize_loras(low_loras),
+              1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index))
 
 
 def create_next_segment(
@@ -913,7 +941,11 @@ def create_next_segment(
     prompt: str,
     start_image_url: str,
     high_loras: Optional[List[str]] = None,
-    low_loras: Optional[List[str]] = None
+    low_loras: Optional[List[str]] = None,
+    faceswap_enabled: bool = False,
+    faceswap_image: Optional[str] = None,
+    faceswap_faces_order: str = "left-right",
+    faceswap_faces_index: str = "0"
 ):
     """Create the next segment for a job (on-demand workflow).
 
@@ -926,14 +958,20 @@ def create_next_segment(
         start_image_url: ComfyUI image URL for the starting image
         high_loras: List of high noise LoRA filenames (max 2)
         low_loras: List of low noise LoRA filenames (max 2)
+        faceswap_enabled: Whether to enable face swapping for this segment
+        faceswap_image: Filename of the face image to swap in
+        faceswap_faces_order: Order to process faces (left-right, right-left, etc.)
+        faceswap_faces_index: Which face indices to process (e.g., "0", "0,1")
     """
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
-            INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?)
+            INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora,
+                                      faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, segment_index, prompt, start_image_url,
-              serialize_loras(high_loras), serialize_loras(low_loras)))
+              serialize_loras(high_loras), serialize_loras(low_loras),
+              1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index))
 
 
 def create_segments_for_job(
@@ -1064,9 +1102,13 @@ def update_segment_prompt(
     segment_index: int,
     prompt: str,
     high_loras: Optional[List[str]] = None,
-    low_loras: Optional[List[str]] = None
+    low_loras: Optional[List[str]] = None,
+    faceswap_enabled: Optional[bool] = None,
+    faceswap_image: Optional[str] = None,
+    faceswap_faces_order: Optional[str] = None,
+    faceswap_faces_index: Optional[str] = None
 ):
-    """Update a segment's prompt and optionally its LoRA selections.
+    """Update a segment's prompt and optionally its LoRA and faceswap settings.
 
     Args:
         job_id: The job ID
@@ -1074,6 +1116,10 @@ def update_segment_prompt(
         prompt: The new prompt
         high_loras: List of high noise LoRA filenames (max 2), or None to not update
         low_loras: List of low noise LoRA filenames (max 2), or None to not update
+        faceswap_enabled: Whether to enable face swapping, or None to not update
+        faceswap_image: Face image filename, or None to not update
+        faceswap_faces_order: Faces order, or None to not update
+        faceswap_faces_index: Faces index, or None to not update
     """
     with get_connection() as conn:
         cursor = conn.cursor()
@@ -1088,6 +1134,22 @@ def update_segment_prompt(
         if low_loras is not None:
             updates.append("low_lora = ?")
             params.append(serialize_loras(low_loras))
+
+        if faceswap_enabled is not None:
+            updates.append("faceswap_enabled = ?")
+            params.append(1 if faceswap_enabled else 0)
+
+        if faceswap_image is not None:
+            updates.append("faceswap_image = ?")
+            params.append(faceswap_image)
+
+        if faceswap_faces_order is not None:
+            updates.append("faceswap_faces_order = ?")
+            params.append(faceswap_faces_order)
+
+        if faceswap_faces_index is not None:
+            updates.append("faceswap_faces_index = ?")
+            params.append(faceswap_faces_index)
 
         params.extend([job_id, segment_index])
 

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -496,11 +496,11 @@ class QueueManager:
         job_name = job.get("name", f"job_{job_id}")
         output_prefix = f"{job_name}_seg{segment_index}"
 
-        # Get faceswap settings from job parameters
-        faceswap_enabled = params.get("faceswap_enabled", False)
-        faceswap_image = params.get("faceswap_image", "")
-        faceswap_faces_order = params.get("faceswap_faces_order", "left-right")
-        faceswap_faces_index = params.get("faceswap_faces_index", "0")
+        # Get faceswap settings from segment (per-segment faceswap)
+        faceswap_enabled = bool(segment.get("faceswap_enabled", 0))
+        faceswap_image = segment.get("faceswap_image", "") or ""
+        faceswap_faces_order = segment.get("faceswap_faces_order", "left-right") or "left-right"
+        faceswap_faces_index = segment.get("faceswap_faces_index", "0") or "0"
 
         # Get frame interpolation setting
         frame_interpolation = params.get("frame_interpolation", "none")

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -391,12 +391,18 @@ async def create_new_job(job: JobCreate):
 
     # Create only the first segment (on-demand workflow)
     # Additional segments will be created when user provides prompts
+    # Extract faceswap settings from job parameters for first segment
+    params = job.parameters or {}
     create_first_segment(
         job_id,
         full_prompt,
         start_image_url,
         high_loras=high_loras if high_loras else None,
-        low_loras=low_loras if low_loras else None
+        low_loras=low_loras if low_loras else None,
+        faceswap_enabled=params.get("faceswap_enabled", False),
+        faceswap_image=params.get("faceswap_image", ""),
+        faceswap_faces_order=params.get("faceswap_faces_order", "left-right"),
+        faceswap_faces_index=params.get("faceswap_faces_index", "0")
     )
     
     return get_job(job_id)
@@ -739,7 +745,11 @@ async def update_segment_prompt_endpoint(
     segment_index: int,
     prompt: str = Form(...),
     loras: Optional[str] = Form(None),  # JSON array: '[{"high_file": "...", "low_file": "..."}]'
-    auto_finalize: Optional[bool] = Form(False)  # Auto-finalize after this segment completes
+    auto_finalize: Optional[bool] = Form(False),  # Auto-finalize after this segment completes
+    faceswap_enabled: Optional[bool] = Form(False),  # Enable faceswap for this segment
+    faceswap_image: Optional[str] = Form(None),  # Face image filename
+    faceswap_faces_order: Optional[str] = Form("left-right"),  # Faces order
+    faceswap_faces_index: Optional[str] = Form("0")  # Faces index
 ):
     """Create or update a segment with a prompt and resume job processing (on-demand workflow).
 
@@ -747,6 +757,10 @@ async def update_segment_prompt_endpoint(
         loras: Optional JSON string containing array of LoRA pairs (max 2).
                Format: '[{"high_file": "path/to/high.safetensors", "low_file": "path/to/low.safetensors"}]'
         auto_finalize: If true, automatically finalize the job after this segment completes.
+        faceswap_enabled: Whether to enable face swapping for this segment.
+        faceswap_image: Filename of the face image to swap in (in ComfyUI input folder).
+        faceswap_faces_order: Order to process faces (left-right, right-left, etc.).
+        faceswap_faces_index: Which face indices to process (e.g., "0", "0,1").
     """
     job = get_job(job_id)
     if not job:
@@ -813,14 +827,22 @@ async def update_segment_prompt_endpoint(
             full_prompt,
             start_image_url,
             high_loras=high_loras if high_loras else None,
-            low_loras=low_loras if low_loras else None
+            low_loras=low_loras if low_loras else None,
+            faceswap_enabled=faceswap_enabled or False,
+            faceswap_image=faceswap_image or "",
+            faceswap_faces_order=faceswap_faces_order or "left-right",
+            faceswap_faces_index=faceswap_faces_index or "0"
         )
     else:
-        # Segment exists - update its prompt and LoRA selections
+        # Segment exists - update its prompt, LoRA, and faceswap settings
         update_segment_prompt(
             job_id, segment_index, full_prompt,
             high_loras=high_loras if high_loras else None,
-            low_loras=low_loras if low_loras else None
+            low_loras=low_loras if low_loras else None,
+            faceswap_enabled=faceswap_enabled,
+            faceswap_image=faceswap_image,
+            faceswap_faces_order=faceswap_faces_order,
+            faceswap_faces_index=faceswap_faces_index
         )
 
     # Update auto_finalize in job parameters

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -205,7 +205,7 @@ class APIClient {
     return `${API_BASE_URL}/jobs/${jobId}/segments/${segmentIndex}/video`;
   }
 
-  async submitSegmentPrompt(jobId, segmentIndex, prompt, loras = [], autoFinalize = false) {
+  async submitSegmentPrompt(jobId, segmentIndex, prompt, loras = [], autoFinalize = false, faceswapOptions = null) {
     const formData = new FormData();
     formData.append('prompt', prompt);
 
@@ -228,6 +228,14 @@ class APIClient {
 
     // Auto-finalize flag
     formData.append('auto_finalize', autoFinalize.toString());
+
+    // Faceswap options (per-segment)
+    if (faceswapOptions) {
+      formData.append('faceswap_enabled', (faceswapOptions.enabled || false).toString());
+      formData.append('faceswap_image', faceswapOptions.image || '');
+      formData.append('faceswap_faces_order', faceswapOptions.facesOrder || 'left-right');
+      formData.append('faceswap_faces_index', faceswapOptions.facesIndex || '0');
+    }
 
     return this.request(`/jobs/${jobId}/segments/${segmentIndex}/prompt`, {
       method: 'POST',

--- a/react-app/src/components/SubmitPromptModal.jsx
+++ b/react-app/src/components/SubmitPromptModal.jsx
@@ -1,15 +1,30 @@
 import { useState, useEffect, useRef } from 'react';
-import { Button, TextField, FormControlLabel, Checkbox, FormHelperText, CircularProgress } from '@mui/material';
+import { Button, TextField, FormControlLabel, Checkbox, FormHelperText, CircularProgress, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import API from '../api/client';
 import { showToast } from '../utils/helpers';
 import LoraAutocomplete from './LoraAutocomplete';
 import './CreateJobModal.css';
+
+// Available face swap images (in ComfyUI input folder)
+// Configure these values to match your local face image files
+const FACESWAP_FACES = [
+  { value: 'Andrea_all.safetensors.png', label: 'Andrea' },
+  { value: 'Chelsea_all.safetensors.png', label: 'Chelsea' },
+  { value: 'gena.safetensors.png', label: 'Gena' },
+  { value: 'Kelly__all.safetensors.png', label: 'Kelly (All)' },
+  { value: 'Kelly_young.safetensors.png', label: 'Kelly (Young)' },
+  { value: 'Kelly_20251124.safetensors.png', label: 'Kelly (2025)' },
+  { value: 'Kerry_all.safetensors.png', label: 'Kerry' },
+  { value: 'Me.safetensors.png', label: 'Me' },
+  { value: 'Udycz_all.safetensors.png', label: 'Udycz' },
+];
 
 export default function SubmitPromptModal({
   jobId,
   segmentIndex,
   defaultPrompt = '',
   defaultLoras = [],  // Array of {high_file, high_weight, low_file, low_weight} pairs
+  defaultFaceswap = null,  // {enabled, image, facesOrder, facesIndex} from previous segment or job
   onClose,
   onSuccess
 }) {
@@ -23,6 +38,12 @@ export default function SubmitPromptModal({
   const [submitting, setSubmitting] = useState(false);
   const [autoFinalize, setAutoFinalize] = useState(false);
   const defaultsAppliedRef = useRef(false);
+
+  // Faceswap state (initialized from defaults)
+  const [faceswapEnabled, setFaceswapEnabled] = useState(defaultFaceswap?.enabled || false);
+  const [faceswapImage, setFaceswapImage] = useState(defaultFaceswap?.image || FACESWAP_FACES[0]?.value || '');
+  const [faceswapFacesOrder, setFaceswapFacesOrder] = useState(defaultFaceswap?.facesOrder || 'left-right');
+  const [faceswapFacesIndex, setFaceswapFacesIndex] = useState(defaultFaceswap?.facesIndex || '0');
 
   useEffect(() => {
     loadLoras();
@@ -137,12 +158,21 @@ export default function SubmitPromptModal({
           low_weight: slot.lowWeight
         }));
 
+      // Build faceswap options
+      const faceswapOptions = {
+        enabled: faceswapEnabled,
+        image: faceswapEnabled ? faceswapImage : '',
+        facesOrder: faceswapEnabled ? faceswapFacesOrder : 'left-right',
+        facesIndex: faceswapEnabled ? faceswapFacesIndex : '0'
+      };
+
       await API.submitSegmentPrompt(
         jobId,
         segmentIndex,
         prompt.trim(),
         lorasArray,
-        autoFinalize
+        autoFinalize,
+        faceswapOptions
       );
 
       showToast('Prompt submitted successfully', 'success');
@@ -328,6 +358,69 @@ export default function SubmitPromptModal({
                 disabled={!selectedLoras[1].lora}
               />
             </div>
+          </div>
+
+          {/* Face Swap */}
+          <div className="form-group" style={{
+            marginTop: '16px',
+            padding: '12px',
+            background: '#f5f5f5',
+            borderRadius: '8px',
+            border: '1px solid #e0e0e0'
+          }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={faceswapEnabled}
+                  onChange={(e) => setFaceswapEnabled(e.target.checked)}
+                />
+              }
+              label={<span style={{ fontWeight: 500 }}>Enable Face Swap (ReActor)</span>}
+            />
+            {faceswapEnabled && (
+              <>
+                <FormControl fullWidth variant="outlined" size="small" sx={{ mt: 1 }}>
+                  <InputLabel>Face</InputLabel>
+                  <Select
+                    value={faceswapImage}
+                    onChange={(e) => setFaceswapImage(e.target.value)}
+                    label="Face"
+                  >
+                    {FACESWAP_FACES.map((face) => (
+                      <MenuItem key={face.value} value={face.value}>
+                        {face.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
+                  <FormControl variant="outlined" size="small" sx={{ flex: 1 }}>
+                    <InputLabel>Faces Order</InputLabel>
+                    <Select
+                      value={faceswapFacesOrder}
+                      onChange={(e) => setFaceswapFacesOrder(e.target.value)}
+                      label="Faces Order"
+                    >
+                      <MenuItem value="left-right">Left to Right</MenuItem>
+                      <MenuItem value="right-left">Right to Left</MenuItem>
+                      <MenuItem value="top-bottom">Top to Bottom</MenuItem>
+                      <MenuItem value="bottom-top">Bottom to Top</MenuItem>
+                      <MenuItem value="small-large">Small to Large</MenuItem>
+                      <MenuItem value="large-small">Large to Small</MenuItem>
+                    </Select>
+                  </FormControl>
+                  <TextField
+                    label="Faces Index"
+                    value={faceswapFacesIndex}
+                    onChange={(e) => setFaceswapFacesIndex(e.target.value)}
+                    variant="outlined"
+                    size="small"
+                    sx={{ width: '120px' }}
+                    helperText="e.g. 0 or 0,1"
+                  />
+                </div>
+              </>
+            )}
           </div>
 
           {/* Auto Finalize */}

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -300,6 +300,42 @@ export default function JobDetail() {
     return result;
   }
 
+  // Build defaultFaceswap object for SubmitPromptModal (from previous segment or job params)
+  function buildDefaultFaceswap(segment, jobParams) {
+    // First try to get from segment (previous segment's settings)
+    if (segment && segment.faceswap_enabled) {
+      return {
+        enabled: Boolean(segment.faceswap_enabled),
+        image: segment.faceswap_image || '',
+        facesOrder: segment.faceswap_faces_order || 'left-right',
+        facesIndex: segment.faceswap_faces_index || '0'
+      };
+    }
+    // Fall back to job parameters (initial job settings)
+    if (jobParams && jobParams.faceswap_enabled) {
+      return {
+        enabled: Boolean(jobParams.faceswap_enabled),
+        image: jobParams.faceswap_image || '',
+        facesOrder: jobParams.faceswap_faces_order || 'left-right',
+        facesIndex: jobParams.faceswap_faces_index || '0'
+      };
+    }
+    return null;
+  }
+
+  // Get faceswap display name from image filename
+  function getFaceswapDisplayName(faceswapImage) {
+    if (!faceswapImage) return null;
+    // Extract name from filename like "Andrea_all.safetensors.png"
+    let name = faceswapImage
+      .replace('.safetensors.png', '')
+      .replace('_all', '')
+      .replace('_young', ' (Young)')
+      .replace('_20251124', ' (2025)');
+    // Capitalize first letter
+    return name.charAt(0).toUpperCase() + name.slice(1);
+  }
+
   // Format LoRAs for display (includes weights, friendly names, and lora objects)
   function formatLorasDisplay(highLora, lowLora) {
     const highLoras = parseLoraArray(highLora);
@@ -620,6 +656,17 @@ export default function JobDetail() {
                       </div>
                     );
                   })()}
+                  {/* Per-segment Faceswap Info */}
+                  <div style={{ marginTop: '8px' }}>
+                    <strong>Face Swap:</strong>{' '}
+                    {seg.faceswap_enabled ? (
+                      <span style={{ color: '#7b1fa2' }}>
+                        {getFaceswapDisplayName(seg.faceswap_image) || 'Enabled'}
+                      </span>
+                    ) : (
+                      <span style={{ color: '#999' }}>N/A</span>
+                    )}
+                  </div>
                 </div>
 
                 {/* End Image */}
@@ -812,6 +859,7 @@ export default function JobDetail() {
           segmentIndex={nextSegmentIndex}
           defaultPrompt={lastCompletedSegment?.prompt || ''}
           defaultLoras={buildDefaultLoras(lastCompletedSegment)}
+          defaultFaceswap={buildDefaultFaceswap(lastCompletedSegment, job?.parameters)}
           onClose={() => setShowPromptModal(false)}
           onSuccess={() => {
             setShowPromptModal(false);


### PR DESCRIPTION
Allow faceswap settings to be configured individually for each segment rather than applying the same settings to the entire video.

Backend:
- Add faceswap columns to job_segments table (enabled, image, order, index)
- Update create_first_segment/create_next_segment to accept faceswap params
- Update update_segment_prompt to accept faceswap params
- Change queue_manager to read faceswap from segment instead of job params
- Add faceswap form fields to segment prompt API endpoint

Frontend:
- Add faceswap options UI to SubmitPromptModal
- Pass defaultFaceswap prop (inherited from previous segment or job)
- Show per-segment faceswap info in JobDetail segments list
- Update API client to send faceswap options with prompt submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)