### PR TITLE
Add soft delete for segments to preserve historical data

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -198,6 +198,12 @@ def init_db():
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+        # Add deleted_at column for soft delete (preserves historical data)
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN deleted_at TIMESTAMP")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
         # Add priority column for queue ordering (lower number = higher priority)
         try:
             cursor.execute("ALTER TABLE jobs ADD COLUMN priority INTEGER DEFAULT 0")
@@ -1230,14 +1236,33 @@ def delete_job_segments(job_id: int):
 
 
 def delete_segment(job_id: int, segment_index: int) -> bool:
-    """Delete a specific segment from a job.
+    """Soft delete a specific segment from a job.
 
-    Returns True if the segment was deleted, False otherwise.
+    Sets deleted_at timestamp instead of actually removing the row.
+    This preserves historical data while excluding from finalization.
+
+    Returns True if the segment was soft deleted, False otherwise.
     """
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(
-            "DELETE FROM job_segments WHERE job_id = ? AND segment_index = ?",
+            "UPDATE job_segments SET deleted_at = ? WHERE job_id = ? AND segment_index = ? AND deleted_at IS NULL",
+            (utc_now_iso(), job_id, segment_index)
+        )
+        return cursor.rowcount > 0
+
+
+def restore_segment(job_id: int, segment_index: int) -> bool:
+    """Restore a soft-deleted segment.
+
+    Clears the deleted_at timestamp to bring the segment back.
+
+    Returns True if the segment was restored, False otherwise.
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE job_segments SET deleted_at = NULL WHERE job_id = ? AND segment_index = ? AND deleted_at IS NOT NULL",
             (job_id, segment_index)
         )
         return cursor.rowcount > 0

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -818,17 +818,17 @@ class QueueManager:
         return False
 
     def _finalize_job(self, job_id: int):
-        """Finalize a job by stitching all completed segment videos together."""
+        """Finalize a job by stitching all completed (non-deleted) segment videos together."""
         # Get job info for naming the final video
         job = get_job(job_id)
         job_name = job.get("name", f"job_{job_id}")
         finalized_at = datetime.now().isoformat()
 
-        # Get all completed segments
+        # Get all completed segments (excluding deleted ones)
         segments = get_job_segments(job_id)
-        completed_segments = [s for s in segments if s.get("status") == "completed"]
+        completed_segments = [s for s in segments if s.get("status") == "completed" and not s.get("deleted_at")]
 
-        print(f"[QueueManager] Finalizing job {job_id} - stitching {len(completed_segments)} segment(s)")
+        print(f"[QueueManager] Finalizing job {job_id} - stitching {len(completed_segments)} segment(s) (deleted segments excluded)")
 
         # Collect all segment video paths
         video_paths = []

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -34,6 +34,7 @@ from database import (
     get_segment,
     delete_job_segments,
     delete_segment,
+    restore_segment,
     get_completed_segments_count,
     get_all_loras as db_get_all_loras,
     get_lora as db_get_lora,
@@ -600,17 +601,17 @@ async def retry_job(job_id: int):
 
 @router.post("/jobs/{job_id}/finalize")
 async def finalize_job(job_id: int):
-    """Finalize a job and merge all completed segments into final video."""
+    """Finalize a job and merge all completed (non-deleted) segments into final video."""
     job = get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    # Get all segments to check if we have any completed
+    # Get all segments to check if we have any completed (excluding deleted)
     segments = db_get_job_segments(job_id)
-    completed_segments = [s for s in segments if s.get("status") == "completed"]
+    completed_segments = [s for s in segments if s.get("status") == "completed" and not s.get("deleted_at")]
 
     if len(completed_segments) == 0:
-        raise HTTPException(status_code=400, detail="No completed segments to finalize")
+        raise HTTPException(status_code=400, detail="No completed segments to finalize (deleted segments are excluded)")
 
     # Update job status to 'running' and trigger finalization through queue manager
     update_job_status(job_id, "running")
@@ -622,7 +623,7 @@ async def finalize_job(job_id: int):
         "status": "finalizing",
         "id": job_id,
         "completed_segments": len(completed_segments),
-        "message": "Job is being finalized. All completed segments will be merged into final video."
+        "message": "Job is being finalized. All completed (non-deleted) segments will be merged into final video."
     }
 
 
@@ -925,53 +926,73 @@ async def update_segment_prompt_endpoint(
 
 @router.delete("/jobs/{job_id}/segments/{segment_index}")
 async def delete_segment_endpoint(job_id: int, segment_index: int):
-    """Delete a specific segment from a job.
+    """Soft delete a specific segment from a job.
 
-    Can only delete the last segment, and only when the job is in awaiting_prompt status.
+    Marks the segment as deleted (preserves historical data) rather than removing it.
+    Deleted segments are excluded from the final video merge but remain visible for reference.
     """
     # Get job and validate
     job = get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    # Validate job status
-    if job.get("status") != "awaiting_prompt":
+    # Validate job status - allow deletion when awaiting_prompt or completed (for cleanup)
+    if job.get("status") not in ("awaiting_prompt", "completed"):
         raise HTTPException(
             status_code=400,
-            detail="Can only delete segments when job is awaiting prompt"
+            detail="Can only delete segments when job is awaiting prompt or completed"
         )
 
-    # Get all segments to validate this is the last one
-    segments = db_get_job_segments(job_id)
-    if not segments:
-        raise HTTPException(status_code=404, detail="No segments found for this job")
+    # Validate the segment exists and is not already deleted
+    segment = get_segment(job_id, segment_index)
+    if not segment:
+        raise HTTPException(status_code=404, detail="Segment not found")
 
-    # Find the highest segment index (last segment)
-    max_segment_index = max(seg["segment_index"] for seg in segments)
+    if segment.get("deleted_at"):
+        raise HTTPException(status_code=400, detail="Segment is already deleted")
 
-    # Validate that we're deleting the last segment
-    if segment_index != max_segment_index:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Can only delete the last segment (segment {max_segment_index}). To delete segment {segment_index}, first delete segments {max_segment_index} down to {segment_index + 1}."
-        )
+    # Soft delete the segment
+    success = delete_segment(job_id, segment_index)
+
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to delete segment")
+
+    return {
+        "status": "success",
+        "message": f"Segment {segment_index} deleted (soft delete - data preserved)",
+        "job_status": job.get("status")
+    }
+
+
+@router.post("/jobs/{job_id}/segments/{segment_index}/restore")
+async def restore_segment_endpoint(job_id: int, segment_index: int):
+    """Restore a soft-deleted segment.
+
+    Brings back a previously deleted segment so it can be included in the final merge.
+    """
+    # Get job and validate
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
 
     # Validate the segment exists
     segment = get_segment(job_id, segment_index)
     if not segment:
         raise HTTPException(status_code=404, detail="Segment not found")
 
-    # Delete the segment
-    success = delete_segment(job_id, segment_index)
+    if not segment.get("deleted_at"):
+        raise HTTPException(status_code=400, detail="Segment is not deleted")
+
+    # Restore the segment
+    success = restore_segment(job_id, segment_index)
 
     if not success:
-        raise HTTPException(status_code=500, detail="Failed to delete segment")
+        raise HTTPException(status_code=500, detail="Failed to restore segment")
 
-    # Job remains in awaiting_prompt status
     return {
         "status": "success",
-        "message": f"Segment {segment_index} deleted successfully",
-        "job_status": "awaiting_prompt"
+        "message": f"Segment {segment_index} restored",
+        "job_status": job.get("status")
     }
 
 

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -259,6 +259,12 @@ class APIClient {
     });
   }
 
+  async restoreSegment(jobId, segmentIndex) {
+    return this.request(`/jobs/${jobId}/segments/${segmentIndex}/restore`, {
+      method: 'POST'
+    });
+  }
+
   // ============== Image Upload ==============
 
   async uploadImage(file) {

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -224,15 +224,27 @@ export default function JobDetail() {
   }
 
   async function handleDeleteSegment(segmentIndex) {
-    if (!confirm(`Are you sure you want to delete Segment ${segmentIndex + 1}?`)) return;
+    if (!confirm(`Are you sure you want to delete Segment ${segmentIndex + 1}? (Data will be preserved but excluded from final video)`)) return;
 
     try {
       await API.deleteSegment(id, segmentIndex);
-      showToast('Segment deleted successfully', 'success');
+      showToast('Segment deleted (data preserved)', 'success');
       await loadJobDetail();
     } catch (error) {
       console.error('Failed to delete segment:', error);
       const errorMessage = error.response?.data?.detail || error.message || 'Failed to delete segment';
+      showToast(errorMessage, 'error');
+    }
+  }
+
+  async function handleRestoreSegment(segmentIndex) {
+    try {
+      await API.restoreSegment(id, segmentIndex);
+      showToast('Segment restored', 'success');
+      await loadJobDetail();
+    } catch (error) {
+      console.error('Failed to restore segment:', error);
+      const errorMessage = error.response?.data?.detail || error.message || 'Failed to restore segment';
       showToast(errorMessage, 'error');
     }
   }
@@ -266,11 +278,12 @@ export default function JobDetail() {
   const segmentDuration = job.segment_duration ?? params.segment_duration ?? 5;
   const fps = job.fps ?? params.fps ?? 16;
 
-  const lastCompletedSegment = segments.filter(s => s.status === 'completed').pop();
+  // Exclude deleted segments when calculating last completed and totals
+  const lastCompletedSegment = segments.filter(s => s.status === 'completed' && !s.deleted_at).pop();
 
-  // Calculate total execution time from all completed segments
+  // Calculate total execution time from all completed (non-deleted) segments
   const totalExecutionTime = segments
-    .filter(s => s.status === 'completed' && s.execution_time)
+    .filter(s => s.status === 'completed' && s.execution_time && !s.deleted_at)
     .reduce((sum, s) => sum + s.execution_time, 0);
 
   // Format time as mm:ss or hh:mm:ss
@@ -635,17 +648,44 @@ export default function JobDetail() {
 
         {segments.length === 0 ? (
           <div className="alert info">No segments yet</div>
-        ) : (
-          segments.map((seg, index) => {
-            // Check if this is the last segment
-            const isLastSegment = index === segments.length - 1;
-            const canDelete = job.status === 'awaiting_prompt' && isLastSegment;
+        ) : (() => {
+          // Calculate display numbers: active segments get sequential numbers, deleted segments show original
+          let activeCount = 0;
+          return segments.map((seg, index) => {
+            // Soft delete: segment has deleted_at timestamp
+            const isDeleted = !!seg.deleted_at;
+            // For display: active segments get sequential numbers (1, 2, 3...)
+            // Deleted segments show their original number with strikethrough
+            const displayNumber = isDeleted ? seg.segment_index + 1 : ++activeCount;
+            // Can delete any non-deleted segment when job allows it
+            const canDelete = !isDeleted && (job.status === 'awaiting_prompt' || job.status === 'completed');
+            // Can restore deleted segments
+            const canRestore = isDeleted;
 
             return (
-              <div key={seg.id} className="segment-item">
+              <div
+                key={seg.id}
+                className="segment-item"
+                style={isDeleted ? { opacity: 0.5, backgroundColor: '#f5f5f5' } : {}}
+              >
                 <div className="segment-header">
                   <div>
-                    <strong>Segment {seg.segment_index + 1}</strong>
+                    <strong style={isDeleted ? { textDecoration: 'line-through', color: '#999' } : {}}>
+                      Segment {displayNumber}
+                    </strong>
+                    {isDeleted && (
+                      <span style={{
+                        marginLeft: '8px',
+                        padding: '2px 8px',
+                        backgroundColor: '#e0e0e0',
+                        color: '#666',
+                        borderRadius: '4px',
+                        fontSize: '11px',
+                        fontWeight: 500
+                      }}>
+                        DELETED
+                      </span>
+                    )}
                     {seg.status === 'running' && <CircularProgress size={16} sx={{ ml: 1 }} />}
                     {seg.execution_time && (
                       <span style={{ marginLeft: '8px', color: '#666', fontSize: '12px' }}>
@@ -654,7 +694,19 @@ export default function JobDetail() {
                     )}
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                    <StatusChip status={seg.status} />
+                    {!isDeleted && <StatusChip status={seg.status} />}
+                    {canRestore && (
+                      <Button
+                        variant="outlined"
+                        color="primary"
+                        size="small"
+                        onClick={() => handleRestoreSegment(seg.segment_index)}
+                        startIcon={<span>↩️</span>}
+                        sx={{ minWidth: 'auto' }}
+                      >
+                        Restore
+                      </Button>
+                    )}
                     {canDelete && (
                       <Button
                         variant="outlined"
@@ -842,8 +894,8 @@ export default function JobDetail() {
               </div>
             </div>
             );
-          })
-        )}
+          });
+        })()}
 
         {/* Continue or Finalize */}
         {job.status === 'awaiting_prompt' && (


### PR DESCRIPTION
Segments are now soft-deleted (marked with deleted_at timestamp) instead of permanently removed. This preserves historical data for reviewing what worked and what didn't.

Changes:
- Add deleted_at column to job_segments table
- Update delete endpoint to soft delete any segment (not just last)
- Add restore endpoint to bring back deleted segments
- Exclude deleted segments from final video merge
- Frontend shows deleted segments greyed out with DELETED badge
- Active segments numbered sequentially (deleted segments keep original number)
- Restore button available on deleted segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)