### PR TITLE
Fix wrong start image when deleting a segment (#78)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1090,6 +1090,31 @@ def get_segment(job_id: int, segment_index: int) -> Optional[Dict[str, Any]]:
         return dict(row) if row else None
 
 
+def get_last_active_segment_before(job_id: int, before_index: int) -> Optional[Dict[str, Any]]:
+    """Get the last non-deleted, completed segment before a given index.
+
+    Used to determine the correct start image for a new segment when
+    previous segments may have been soft-deleted.
+
+    Returns the segment dict if found, or None if no active segment exists
+    before the given index (meaning the original job input image should be used).
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """SELECT * FROM job_segments
+               WHERE job_id = ?
+                 AND segment_index < ?
+                 AND deleted_at IS NULL
+                 AND status = 'completed'
+               ORDER BY segment_index DESC
+               LIMIT 1""",
+            (job_id, before_index)
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+
 def get_next_pending_segment(job_id: int) -> Optional[Dict[str, Any]]:
     """Get the next pending segment for a job."""
     with get_connection() as conn:

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -23,6 +23,7 @@ from database import (
     update_segment_status,
     update_segment_start_image,
     get_completed_segments_count,
+    get_last_active_segment_before,
     parse_loras,
     add_job_log
 )
@@ -305,14 +306,26 @@ class QueueManager:
 
             # Check if segment has a start image (required for all segments)
             if segment_index > 0 and not segment.get("start_image_url"):
-                # Get the previous segment's end frame
-                prev_segment = segments[segment_index - 1]
-                if prev_segment.get("end_frame_url"):
-                    # Update this segment's start image
+                # Find the last non-deleted, completed segment to use as start image
+                # This handles cases where earlier segments were soft-deleted
+                prev_segment = get_last_active_segment_before(job_id, segment_index)
+                if prev_segment and prev_segment.get("end_frame_url"):
+                    # Use the previous active segment's end frame
                     update_segment_start_image(job_id, segment_index, prev_segment["end_frame_url"])
                     segment["start_image_url"] = prev_segment["end_frame_url"]
+                elif job.get("input_image"):
+                    # No active previous segment - use the job's original input image
+                    comfyui_url = get_setting("comfyui_url", "http://localhost:8188")
+                    input_image = job["input_image"]
+                    if input_image.startswith("http"):
+                        start_url = input_image
+                    else:
+                        start_url = f"{comfyui_url}/view?filename={input_image}&subfolder=&type=input"
+                    update_segment_start_image(job_id, segment_index, start_url)
+                    segment["start_image_url"] = start_url
+                    print(f"[QueueManager] Segment {segment_index} using original input image (previous segments deleted)")
                 else:
-                    print(f"[QueueManager] Segment {segment_index} missing start image, waiting for previous segment")
+                    print(f"[QueueManager] Segment {segment_index} missing start image, no fallback available")
                     continue
 
             # Process this segment

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -32,6 +32,7 @@ from database import (
     get_job_segments as db_get_job_segments,
     update_segment_prompt,
     get_segment,
+    get_last_active_segment_before,
     delete_job_segments,
     delete_segment,
     restore_segment,
@@ -870,17 +871,26 @@ async def update_segment_prompt_endpoint(
                 comfyui_url = get_setting("comfyui_url", COMFYUI_SERVER_URL)
                 start_image_url = f"{comfyui_url}/view?filename={input_image}&subfolder=&type=input"
         else:
-            # Get the previous segment's end frame as the start image for this segment
-            previous_segment = get_segment(job_id, segment_index - 1)
-            if not previous_segment:
-                raise HTTPException(status_code=400, detail=f"Previous segment {segment_index - 1} does not exist")
-
-            if previous_segment.get("status") != "completed":
-                raise HTTPException(status_code=400, detail=f"Previous segment {segment_index - 1} must be completed first")
-
-            start_image_url = previous_segment.get("end_frame_url")
-            if not start_image_url:
-                raise HTTPException(status_code=400, detail=f"Previous segment {segment_index - 1} has no end frame")
+            # Find the last non-deleted, completed segment to use as start image
+            # This handles cases where earlier segments were soft-deleted
+            previous_segment = get_last_active_segment_before(job_id, segment_index)
+            if previous_segment:
+                start_image_url = previous_segment.get("end_frame_url")
+                if not start_image_url:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Previous segment {previous_segment['segment_index']} has no end frame"
+                    )
+            else:
+                # No active previous segment - use the job's original input image
+                input_image = job.get("input_image")
+                if not input_image:
+                    raise HTTPException(status_code=400, detail="Job has no input image")
+                if input_image.startswith("http"):
+                    start_image_url = input_image
+                else:
+                    comfyui_url = get_setting("comfyui_url", COMFYUI_SERVER_URL)
+                    start_image_url = f"{comfyui_url}/view?filename={input_image}&subfolder=&type=input"
 
         # Create new segment on-demand
         create_next_segment(


### PR DESCRIPTION
When a segment was deleted and a new segment added, the system incorrectly used the end frame from the deleted segment instead of the original input image or the last active segment's end frame.

- Add get_last_active_segment_before() helper to find last non-deleted, completed segment before a given index
- Update routes.py to use new helper when creating segments on-demand
- Update queue_manager.py to use new helper when determining start image
- Fall back to original job input image when all previous segments deleted