### PR TITLE
Add last_segment_run column to jobs table (#81)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -232,6 +232,12 @@ def init_db():
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+        # Add last_segment_run column to track when last segment completed/failed
+        try:
+            cursor.execute("ALTER TABLE jobs ADD COLUMN last_segment_run TIMESTAMP")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
         # Settings table
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS settings (
@@ -1140,40 +1146,47 @@ def update_segment_status(
     """Update a segment's status and related fields."""
     with get_connection() as conn:
         cursor = conn.cursor()
-        
+
         updates = ["status = ?"]
         params = [status]
-        
+
         if status == "completed":
             updates.append("completed_at = ?")
             params.append(utc_now_iso())
-        
+
         if comfyui_prompt_id is not None:
             updates.append("comfyui_prompt_id = ?")
             params.append(comfyui_prompt_id)
-        
+
         if end_frame_url is not None:
             updates.append("end_frame_url = ?")
             params.append(end_frame_url)
-        
+
         if video_path is not None:
             updates.append("video_path = ?")
             params.append(video_path)
-        
+
         if error_message is not None:
             updates.append("error_message = ?")
             params.append(error_message)
-        
+
         if execution_time is not None:
             updates.append("execution_time = ?")
             params.append(execution_time)
-        
+
         params.extend([job_id, segment_index])
-        
+
         cursor.execute(
             f"UPDATE job_segments SET {', '.join(updates)} WHERE job_id = ? AND segment_index = ?",
             params
         )
+
+        # Update job's last_segment_run when segment completes or fails
+        if status in ("completed", "failed"):
+            cursor.execute(
+                "UPDATE jobs SET last_segment_run = ? WHERE id = ?",
+                (utc_now_iso(), job_id)
+            )
 
 
 def update_segment_prompt(

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -269,6 +269,7 @@ class JobResponse(BaseModel):
     created_at: Optional[str]
     started_at: Optional[str]
     completed_at: Optional[str]
+    last_segment_run: Optional[str] = None
     priority: Optional[int] = None
     seed: Optional[int] = None
     # Computed segment fields

--- a/react-app/src/components/SegmentNotesModal.jsx
+++ b/react-app/src/components/SegmentNotesModal.jsx
@@ -84,7 +84,7 @@ export default function SegmentNotesModal({ jobId, segments, onClose, onUpdate }
               <TableRow>
                 <TableCell sx={{ fontWeight: 600, width: '70px', fontSize: '14px' }}>Seg</TableCell>
                 <TableCell sx={{ fontWeight: 600, width: '100px', fontSize: '14px', textAlign: 'right' }}>Status</TableCell>
-                <TableCell sx={{ fontWeight: 600, width: '150px', fontSize: '14px' }}>Timestamp</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: '150px', fontSize: '14px' }}>Segment Run</TableCell>
                 <TableCell sx={{ fontWeight: 600, width: '28%', fontSize: '14px' }}>Prompt</TableCell>
                 <TableCell sx={{ fontWeight: 600, width: '22%', fontSize: '14px' }}>LoRAs</TableCell>
                 <TableCell sx={{ fontWeight: 600, width: '28%', fontSize: '14px' }}>Note</TableCell>
@@ -112,7 +112,7 @@ export default function SegmentNotesModal({ jobId, segments, onClose, onUpdate }
                       <StatusChip status={isDeleted ? 'deleted' : seg.status} />
                     </TableCell>
                     <TableCell sx={{ fontSize: '13px', color: '#666', pt: 2 }}>
-                      {seg.completed_at ? formatDate(seg.completed_at) : (seg.created_at ? formatDate(seg.created_at) : '-')}
+                      {seg.completed_at ? formatDate(seg.completed_at) : '-'}
                     </TableCell>
                     <TableCell sx={{ fontSize: '13px', pt: 2 }} title={seg.prompt}>
                       {truncatePrompt(seg.prompt)}

--- a/react-app/src/pages/Dashboard.jsx
+++ b/react-app/src/pages/Dashboard.jsx
@@ -89,7 +89,8 @@ export default function Dashboard() {
       ? allJobs
       : allJobs.filter(job => statusFilter.includes(job.status));
 
-    // Sort: awaiting_prompt, running, pending (oldest first), then completed/failed/paused (newest first)
+    // Sort: by status priority first, then by last_segment_run within each status group
+    // NULL last_segment_run values appear last within their status group
     filtered.sort((a, b) => {
       // Priority order for statuses
       const statusPriority = {
@@ -108,19 +109,16 @@ export default function Dashboard() {
         return priorityA - priorityB;
       }
 
-      // For awaiting_prompt/running, sort newest first (by creation date)
-      // For pending, sort oldest first (queue order)
-      // For completed/failed/paused, sort newest first (by completed_at or created_at)
-      if (['awaiting_prompt', 'running'].includes(a.status)) {
-        return new Date(b.created_at) - new Date(a.created_at);
-      } else if (a.status === 'pending') {
-        return new Date(a.created_at) - new Date(b.created_at);
-      } else {
-        // Use completed_at if available, otherwise created_at
-        const dateA = a.completed_at ? new Date(a.completed_at) : new Date(a.created_at);
-        const dateB = b.completed_at ? new Date(b.completed_at) : new Date(b.created_at);
-        return dateB - dateA; // Descending (newest first)
-      }
+      // Within same status group, sort by last_segment_run (newest first, NULL last)
+      const dateA = a.last_segment_run ? new Date(a.last_segment_run) : null;
+      const dateB = b.last_segment_run ? new Date(b.last_segment_run) : null;
+
+      // Handle NULL values - they go last
+      if (dateA === null && dateB === null) return 0;
+      if (dateA === null) return 1;  // A (null) goes after B
+      if (dateB === null) return -1; // B (null) goes after A
+
+      return dateB - dateA; // Descending (newest first)
     });
 
     setFilteredJobs(filtered);
@@ -248,7 +246,7 @@ export default function Dashboard() {
               <TableCell style={{fontWeight:'bold'}}>Faceswap</TableCell>
               <TableCell style={{fontWeight:'bold'}}>Status</TableCell>
               <TableCell style={{fontWeight:'bold'}}>Segments</TableCell>
-              <TableCell style={{fontWeight:'bold'}}>Created</TableCell>
+              <TableCell style={{fontWeight:'bold'}}>Segment Run</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -291,7 +289,7 @@ export default function Dashboard() {
                         </span>
                       )}
                     </TableCell>
-                    <TableCell>{formatDate(job.created_at)}</TableCell>
+                    <TableCell>{job.last_segment_run ? formatDate(job.last_segment_run) : '-'}</TableCell>
                   </TableRow>
                 ))
             )}

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -688,9 +688,9 @@ export default function JobDetail() {
                       Segment {displayNumber}
                     </strong>
                     {seg.status === 'running' && <CircularProgress size={16} sx={{ ml: 1 }} />}
-                    {seg.execution_time && (
+                    {(seg.completed_at || seg.execution_time) && (
                       <span style={{ marginLeft: '8px', color: '#666', fontSize: '12px' }}>
-                        ({formatExecutionTime(seg.execution_time)})
+                        ({seg.completed_at ? formatDate(seg.completed_at) : ''}{seg.completed_at && seg.execution_time ? ' | ' : ''}{seg.execution_time ? formatExecutionTime(seg.execution_time) : ''})
                       </span>
                     )}
                   </div>

--- a/react-app/src/pages/Queue.jsx
+++ b/react-app/src/pages/Queue.jsx
@@ -80,7 +80,8 @@ export default function Queue() {
       ? allJobs
       : allJobs.filter(job => statusFilter.includes(job.status));
 
-    // Sort: awaiting_prompt, running, pending (oldest first), then completed/failed/paused (newest first)
+    // Sort: by status priority first, then by last_segment_run within each status group
+    // Pending jobs keep their priority order, NULL last_segment_run values appear last
     filtered.sort((a, b) => {
       // Priority order for statuses
       const statusPriority = {
@@ -99,20 +100,21 @@ export default function Queue() {
         return priorityA - priorityB;
       }
 
-      // For awaiting_prompt/running, sort newest first (by creation date)
-      // For pending, sort by priority (lower number = higher priority)
-      // For completed/failed/paused, sort newest first (by completed_at or created_at)
-      if (['awaiting_prompt', 'running'].includes(a.status)) {
-        return new Date(b.created_at) - new Date(a.created_at);
-      } else if (a.status === 'pending') {
-        // Sort by priority (lower number = higher in queue)
+      // For pending, sort by priority (lower number = higher in queue)
+      if (a.status === 'pending') {
         return (a.priority || 0) - (b.priority || 0);
-      } else {
-        // Use completed_at if available, otherwise created_at
-        const dateA = a.completed_at ? new Date(a.completed_at) : new Date(a.created_at);
-        const dateB = b.completed_at ? new Date(b.completed_at) : new Date(b.created_at);
-        return dateB - dateA; // Descending (newest first)
       }
+
+      // For other statuses, sort by last_segment_run (newest first, NULL last)
+      const dateA = a.last_segment_run ? new Date(a.last_segment_run) : null;
+      const dateB = b.last_segment_run ? new Date(b.last_segment_run) : null;
+
+      // Handle NULL values - they go last
+      if (dateA === null && dateB === null) return 0;
+      if (dateA === null) return 1;  // A (null) goes after B
+      if (dateB === null) return -1; // B (null) goes after A
+
+      return dateB - dateA; // Descending (newest first)
     });
 
     setJobs(filtered);
@@ -236,7 +238,7 @@ export default function Queue() {
               <TableCell style={{fontWeight:'bold'}}></TableCell>
               <TableCell style={{fontWeight:'bold'}}>Job Name</TableCell>
               <TableCell style={{fontWeight:'bold'}}>Faceswap</TableCell>
-              <TableCell style={{fontWeight:'bold'}}>Created</TableCell>
+              <TableCell style={{fontWeight:'bold'}}>Segment Run</TableCell>
               <TableCell style={{fontWeight:'bold'}}>Status</TableCell>
               <TableCell style={{fontWeight:'bold'}}>Segments</TableCell>
             </TableRow>
@@ -302,7 +304,7 @@ export default function Queue() {
                       <TableCell sx={{ color: getFaceswapName(job) ? 'inherit' : '#999' }}>
                         {getFaceswapName(job) || 'N/A'}
                       </TableCell>
-                      <TableCell>{formatDate(job.created_at)}</TableCell>
+                      <TableCell>{job.last_segment_run ? formatDate(job.last_segment_run) : '-'}</TableCell>
                       <TableCell>
                         <StatusChip status={job.status} />
                       </TableCell>


### PR DESCRIPTION
- Add last_segment_run column to track when segments complete/fail
- Update segment status to set last_segment_run on completion or failure
- Replace "Created" with "Segment Run" in Dashboard and Queue tables
- Sort by status first, then by last_segment_run (NULL values last)
- Update segment timeline to show completed_at timestamp with run time
- Update Segment Notes modal header to "Segment Run"