### PR TITLE
Add fade-to-black transition feature for video segments (#87)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -210,6 +210,12 @@ def init_db():
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+        # Add fade_to_black column for transition effect at segment end
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN fade_to_black INTEGER DEFAULT 0")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
         # Add priority column for queue ordering (lower number = higher priority)
         try:
             cursor.execute("ALTER TABLE jobs ADD COLUMN priority INTEGER DEFAULT 0")
@@ -958,7 +964,8 @@ def create_first_segment(
     faceswap_enabled: bool = False,
     faceswap_image: Optional[str] = None,
     faceswap_faces_order: str = "left-right",
-    faceswap_faces_index: str = "0"
+    faceswap_faces_index: str = "0",
+    fade_to_black: bool = False
 ):
     """Create the first segment for a job (on-demand workflow).
 
@@ -975,16 +982,19 @@ def create_first_segment(
         faceswap_image: Filename of the face image to swap in
         faceswap_faces_order: Order to process faces (left-right, right-left, etc.)
         faceswap_faces_index: Which face indices to process (e.g., "0", "0,1")
+        fade_to_black: Whether to apply fade-to-black transition at segment end
     """
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
             INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora,
-                                      faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
+                                      faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index,
+                                      fade_to_black)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, 0, initial_prompt, start_image_url,
               serialize_loras(high_loras), serialize_loras(low_loras),
-              1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index))
+              1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index,
+              1 if fade_to_black else 0))
 
 
 def create_next_segment(
@@ -997,7 +1007,8 @@ def create_next_segment(
     faceswap_enabled: bool = False,
     faceswap_image: Optional[str] = None,
     faceswap_faces_order: str = "left-right",
-    faceswap_faces_index: str = "0"
+    faceswap_faces_index: str = "0",
+    fade_to_black: bool = False
 ):
     """Create the next segment for a job (on-demand workflow).
 
@@ -1014,16 +1025,19 @@ def create_next_segment(
         faceswap_image: Filename of the face image to swap in
         faceswap_faces_order: Order to process faces (left-right, right-left, etc.)
         faceswap_faces_index: Which face indices to process (e.g., "0", "0,1")
+        fade_to_black: Whether to apply fade-to-black transition at segment end
     """
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
             INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora,
-                                      faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
+                                      faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index,
+                                      fade_to_black)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, segment_index, prompt, start_image_url,
               serialize_loras(high_loras), serialize_loras(low_loras),
-              1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index))
+              1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index,
+              1 if fade_to_black else 0))
 
 
 def create_segments_for_job(
@@ -1198,7 +1212,8 @@ def update_segment_prompt(
     faceswap_enabled: Optional[bool] = None,
     faceswap_image: Optional[str] = None,
     faceswap_faces_order: Optional[str] = None,
-    faceswap_faces_index: Optional[str] = None
+    faceswap_faces_index: Optional[str] = None,
+    fade_to_black: Optional[bool] = None
 ):
     """Update a segment's prompt and optionally its LoRA and faceswap settings.
 
@@ -1212,6 +1227,7 @@ def update_segment_prompt(
         faceswap_image: Face image filename, or None to not update
         faceswap_faces_order: Faces order, or None to not update
         faceswap_faces_index: Faces index, or None to not update
+        fade_to_black: Whether to apply fade-to-black transition at segment end, or None to not update
     """
     with get_connection() as conn:
         cursor = conn.cursor()
@@ -1242,6 +1258,10 @@ def update_segment_prompt(
         if faceswap_faces_index is not None:
             updates.append("faceswap_faces_index = ?")
             params.append(faceswap_faces_index)
+
+        if fade_to_black is not None:
+            updates.append("fade_to_black = ?")
+            params.append(1 if fade_to_black else 0)
 
         params.extend([job_id, segment_index])
 
@@ -1330,6 +1350,25 @@ def update_segment_note(job_id: int, segment_index: int, note: str) -> bool:
         cursor.execute(
             "UPDATE job_segments SET note = ? WHERE job_id = ? AND segment_index = ?",
             (note, job_id, segment_index)
+        )
+        return cursor.rowcount > 0
+
+
+def update_segment_fade_to_black(job_id: int, segment_index: int, fade_to_black: bool) -> bool:
+    """Update a segment's fade_to_black setting.
+
+    Args:
+        job_id: The job ID
+        segment_index: The segment index
+        fade_to_black: Whether to apply fade-to-black transition at segment end
+
+    Returns True if the segment was updated, False otherwise.
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE job_segments SET fade_to_black = ? WHERE job_id = ? AND segment_index = ?",
+            (1 if fade_to_black else 0, job_id, segment_index)
         )
         return cursor.rowcount > 0
 

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -843,13 +843,18 @@ class QueueManager:
 
         print(f"[QueueManager] Finalizing job {job_id} - stitching {len(completed_segments)} segment(s) (deleted segments excluded)")
 
-        # Collect all segment video paths
+        # Collect all segment video paths and metadata for fade effects
         video_paths = []
+        segment_info = []
         for segment in completed_segments:
             segment_index = segment["segment_index"]
             video_path = get_segment_video_path(job_id, segment_index)
             if video_path and os.path.exists(video_path):
                 video_paths.append(video_path)
+                # Include segment metadata for fade-to-black effect
+                segment_info.append({
+                    "fade_to_black": bool(segment.get("fade_to_black", 0))
+                })
             else:
                 print(f"[QueueManager] Warning: Segment {segment_index} video not found at {video_path}")
 
@@ -861,7 +866,7 @@ class QueueManager:
 
         # Stitch videos together with descriptive filename
         final_video_path = get_final_video_path(job_id, job_name, finalized_at)
-        if stitch_videos(video_paths, final_video_path):
+        if stitch_videos(video_paths, final_video_path, segment_info=segment_info):
             # Update job with final video path
             update_job_status(job_id, "completed", output_images=[final_video_path])
             self._notify_update(job_id, "completed")

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -37,6 +37,7 @@ from database import (
     delete_segment,
     restore_segment,
     update_segment_note,
+    update_segment_fade_to_black,
     get_completed_segments_count,
     get_all_loras as db_get_all_loras,
     get_lora as db_get_lora,
@@ -451,7 +452,8 @@ async def create_new_job(job: JobCreate):
         faceswap_enabled=params.get("faceswap_enabled", False),
         faceswap_image=params.get("faceswap_image", ""),
         faceswap_faces_order=params.get("faceswap_faces_order", "left-right"),
-        faceswap_faces_index=params.get("faceswap_faces_index", "0")
+        faceswap_faces_index=params.get("faceswap_faces_index", "0"),
+        fade_to_black=params.get("fade_to_black", False)
     )
     
     return get_job(job_id)
@@ -820,7 +822,8 @@ async def update_segment_prompt_endpoint(
     faceswap_enabled: Optional[bool] = Form(False),  # Enable faceswap for this segment
     faceswap_image: Optional[str] = Form(None),  # Face image filename
     faceswap_faces_order: Optional[str] = Form("left-right"),  # Faces order
-    faceswap_faces_index: Optional[str] = Form("0")  # Faces index
+    faceswap_faces_index: Optional[str] = Form("0"),  # Faces index
+    fade_to_black: Optional[bool] = Form(False)  # Apply fade-to-black transition at segment end
 ):
     """Create or update a segment with a prompt and resume job processing (on-demand workflow).
 
@@ -832,6 +835,7 @@ async def update_segment_prompt_endpoint(
         faceswap_image: Filename of the face image to swap in (in ComfyUI input folder).
         faceswap_faces_order: Order to process faces (left-right, right-left, etc.).
         faceswap_faces_index: Which face indices to process (e.g., "0", "0,1").
+        fade_to_black: Apply fade-to-black transition at the end of this segment.
     """
     job = get_job(job_id)
     if not job:
@@ -911,7 +915,8 @@ async def update_segment_prompt_endpoint(
             faceswap_enabled=faceswap_enabled or False,
             faceswap_image=faceswap_image or "",
             faceswap_faces_order=faceswap_faces_order or "left-right",
-            faceswap_faces_index=faceswap_faces_index or "0"
+            faceswap_faces_index=faceswap_faces_index or "0",
+            fade_to_black=fade_to_black or False
         )
     else:
         # Segment exists - update its prompt, LoRA, and faceswap settings
@@ -922,7 +927,8 @@ async def update_segment_prompt_endpoint(
             faceswap_enabled=faceswap_enabled,
             faceswap_image=faceswap_image,
             faceswap_faces_order=faceswap_faces_order,
-            faceswap_faces_index=faceswap_faces_index
+            faceswap_faces_index=faceswap_faces_index,
+            fade_to_black=fade_to_black
         )
 
     # Update auto_finalize in job parameters
@@ -955,11 +961,11 @@ async def delete_segment_endpoint(job_id: int, segment_index: int):
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    # Validate job status - allow deletion when awaiting_prompt or completed (for cleanup)
-    if job.get("status") not in ("awaiting_prompt", "completed"):
+    # Validate job status - only allow deletion on non-finalized jobs
+    if job.get("status") != "awaiting_prompt":
         raise HTTPException(
             status_code=400,
-            detail="Can only delete segments when job is awaiting prompt or completed"
+            detail="Can only delete segments when job is awaiting prompt (not finalized)"
         )
 
     # Validate the segment exists and is not already deleted
@@ -1042,6 +1048,43 @@ async def update_segment_note_endpoint(job_id: int, segment_index: int, note: st
         "status": "success",
         "message": f"Note updated for segment {segment_index}",
         "note": note[:255]
+    }
+
+
+@router.put("/jobs/{job_id}/segments/{segment_index}/fade")
+async def update_segment_fade_endpoint(job_id: int, segment_index: int, fade_to_black: bool = Form(...)):
+    """Update a segment's fade-to-black setting.
+
+    Fade-to-black applies a 2-second fade effect at the end of the segment
+    during video finalization.
+    """
+    # Get job and validate
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Only allow updating fade settings on non-finalized jobs
+    if job.get("status") != "awaiting_prompt":
+        raise HTTPException(
+            status_code=400,
+            detail="Can only update fade settings when job is awaiting prompt (not finalized)"
+        )
+
+    # Validate the segment exists
+    segment = get_segment(job_id, segment_index)
+    if not segment:
+        raise HTTPException(status_code=404, detail="Segment not found")
+
+    # Update the fade setting
+    success = update_segment_fade_to_black(job_id, segment_index, fade_to_black)
+
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to update fade setting")
+
+    return {
+        "status": "success",
+        "message": f"Fade setting updated for segment {segment_index}",
+        "fade_to_black": fade_to_black
     }
 
 

--- a/backend/video_utils.py
+++ b/backend/video_utils.py
@@ -114,27 +114,145 @@ def extract_last_frame(video_path: str, output_image_path: str) -> bool:
         return False
 
 
-def stitch_videos(video_paths: List[str], output_path: str) -> bool:
+def get_video_duration(video_path: str) -> Optional[float]:
+    """Get the duration of a video file in seconds using ffprobe.
+
+    Returns:
+        Duration in seconds, or None if unable to determine.
+    """
+    try:
+        cmd = [
+            "ffprobe",
+            "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
+            video_path
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            return float(result.stdout.strip())
+    except Exception as e:
+        print(f"[VideoUtils] Error getting video duration: {e}")
+    return None
+
+
+def apply_fade_effects(input_path: str, output_path: str, fade_in: bool = False, fade_out: bool = False, fade_duration: float = 2.0) -> bool:
+    """Apply fade-in and/or fade-out effects to a video.
+
+    Args:
+        input_path: Path to the input video
+        output_path: Path where the faded video should be saved
+        fade_in: Whether to fade in from black at the start
+        fade_out: Whether to fade out to black at the end
+        fade_duration: Duration of each fade effect in seconds (default 2.0)
+
+    Returns:
+        True if successful, False otherwise
+    """
+    if not fade_in and not fade_out:
+        return False
+
+    try:
+        # Get video duration to calculate fade start time for fade out
+        duration = get_video_duration(input_path)
+        if duration is None:
+            print(f"[VideoUtils] Could not determine duration of {input_path}")
+            return False
+
+        # Build filter string
+        filters = []
+        if fade_in:
+            filters.append(f"fade=t=in:st=0:d={fade_duration}")
+        if fade_out:
+            fade_start = max(0, duration - fade_duration)
+            filters.append(f"fade=t=out:st={fade_start}:d={fade_duration}")
+
+        filter_string = ",".join(filters)
+
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i", input_path,
+            "-vf", filter_string,
+            "-c:v", "libx264",
+            "-preset", "fast",
+            "-crf", "18",
+            "-pix_fmt", "yuv420p",
+            output_path
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode == 0 and os.path.exists(output_path):
+            effects = []
+            if fade_in:
+                effects.append("fade-in")
+            if fade_out:
+                effects.append("fade-out")
+            print(f"[VideoUtils] Applied {' + '.join(effects)} to {input_path}")
+            return True
+        else:
+            print(f"[VideoUtils] ffmpeg fade error: {result.stderr}")
+            return False
+
+    except Exception as e:
+        print(f"[VideoUtils] Error applying fade: {e}")
+        return False
+
+
+def stitch_videos(video_paths: List[str], output_path: str, segment_info: Optional[List[dict]] = None) -> bool:
     """Stitch multiple videos together using ffmpeg concat demuxer.
-    
+
     Args:
         video_paths: List of paths to video files to concatenate
         output_path: Path where the final stitched video should be saved
-        
+        segment_info: Optional list of dicts with segment metadata. If provided,
+                     should have same length as video_paths. Each dict can contain:
+                     - fade_to_black: bool - whether to apply fade-to-black transition after this segment
+
     Returns:
         True if stitching was successful, False otherwise
     """
     if not video_paths:
         print("[VideoUtils] No videos to stitch")
         return False
-    
-    if len(video_paths) == 1:
-        # Re-encode single video to WebM for Firefox compatibility
-        try:
+
+    # Determine which segments need fade effects
+    # fade_to_black on segment[i] means:
+    #   - fade OUT at end of segment[i]
+    #   - fade IN at start of segment[i+1] (if exists)
+    processed_paths = []
+    temp_files = []
+
+    for i, video_path in enumerate(video_paths):
+        # Check if this segment needs fade-out (has fade_to_black enabled)
+        needs_fade_out = False
+        if segment_info and i < len(segment_info):
+            needs_fade_out = segment_info[i].get("fade_to_black", False)
+
+        # Check if previous segment had fade_to_black (this segment needs fade-in)
+        needs_fade_in = False
+        if segment_info and i > 0 and i - 1 < len(segment_info):
+            needs_fade_in = segment_info[i - 1].get("fade_to_black", False)
+
+        if needs_fade_in or needs_fade_out:
+            temp_path = video_path.replace(".mp4", "_faded.mp4")
+            if apply_fade_effects(video_path, temp_path, fade_in=needs_fade_in, fade_out=needs_fade_out):
+                processed_paths.append(temp_path)
+                temp_files.append(temp_path)
+            else:
+                print(f"[VideoUtils] Fade failed for segment {i}, using original")
+                processed_paths.append(video_path)
+        else:
+            processed_paths.append(video_path)
+
+    try:
+        if len(processed_paths) == 1:
+            # Re-encode single video to WebM for Firefox compatibility
             cmd = [
                 "ffmpeg",
                 "-y",
-                "-i", video_paths[0],
+                "-i", processed_paths[0],
                 "-c:v", "libvpx-vp9",
                 "-crf", "30",
                 "-b:v", "0",
@@ -147,23 +265,23 @@ def stitch_videos(video_paths: List[str], output_path: str) -> bool:
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode == 0 and os.path.exists(output_path):
                 print(f"[VideoUtils] Single video encoded to {output_path}")
+                # Clean up temp files
+                for temp_file in temp_files:
+                    if os.path.exists(temp_file):
+                        os.remove(temp_file)
                 return True
             else:
                 print(f"[VideoUtils] ffmpeg error: {result.stderr}")
                 return False
-        except Exception as e:
-            print(f"[VideoUtils] Error encoding video: {e}")
-            return False
-    
-    try:
+
         # Create a temporary file listing all videos for concat
         with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
-            for video_path in video_paths:
+            for video_path in processed_paths:
                 # Escape single quotes in path
                 escaped_path = video_path.replace("'", "'\\''")
                 f.write(f"file '{escaped_path}'\n")
             concat_file = f.name
-        
+
         # Use VP9/WebM for native Firefox support (no H.264 codec issues)
         cmd = [
             "ffmpeg",
@@ -180,21 +298,28 @@ def stitch_videos(video_paths: List[str], output_path: str) -> bool:
             "-row-mt", "1",  # Multi-threaded row encoding
             output_path
         ]
-        
+
         result = subprocess.run(cmd, capture_output=True, text=True)
-        
-        # Clean up temp file
+
+        # Clean up temp files
         os.unlink(concat_file)
-        
+        for temp_file in temp_files:
+            if os.path.exists(temp_file):
+                os.remove(temp_file)
+
         if result.returncode == 0 and os.path.exists(output_path):
-            print(f"[VideoUtils] Stitched {len(video_paths)} videos to {output_path}")
+            print(f"[VideoUtils] Stitched {len(processed_paths)} videos to {output_path}")
             return True
         else:
             print(f"[VideoUtils] ffmpeg stitch error: {result.stderr}")
             return False
-            
+
     except Exception as e:
         print(f"[VideoUtils] Error stitching videos: {e}")
+        # Clean up temp files on error
+        for temp_file in temp_files:
+            if os.path.exists(temp_file):
+                os.remove(temp_file)
         return False
 
 

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -215,7 +215,7 @@ class APIClient {
     return `${API_BASE_URL}/jobs/${jobId}/segments/${segmentIndex}/video`;
   }
 
-  async submitSegmentPrompt(jobId, segmentIndex, prompt, loras = [], autoFinalize = false, faceswapOptions = null) {
+  async submitSegmentPrompt(jobId, segmentIndex, prompt, loras = [], autoFinalize = false, faceswapOptions = null, fadeToBlack = false) {
     const formData = new FormData();
     formData.append('prompt', prompt);
 
@@ -238,6 +238,9 @@ class APIClient {
 
     // Auto-finalize flag
     formData.append('auto_finalize', autoFinalize.toString());
+
+    // Fade to black flag
+    formData.append('fade_to_black', fadeToBlack.toString());
 
     // Faceswap options (per-segment)
     if (faceswapOptions) {
@@ -269,6 +272,15 @@ class APIClient {
     const formData = new FormData();
     formData.append('note', note);
     return this.request(`/jobs/${jobId}/segments/${segmentIndex}/note`, {
+      method: 'PUT',
+      body: formData
+    });
+  }
+
+  async updateSegmentFade(jobId, segmentIndex, fadeToBlack) {
+    const formData = new FormData();
+    formData.append('fade_to_black', fadeToBlack.toString());
+    return this.request(`/jobs/${jobId}/segments/${segmentIndex}/fade`, {
       method: 'PUT',
       body: formData
     });

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Button, CircularProgress, LinearProgress, Box, Typography } from '@mui/material';
+import { Button, CircularProgress, LinearProgress, Box, Typography, Checkbox, FormControlLabel } from '@mui/material';
+import SwitchVideoIcon from '@mui/icons-material/SwitchVideo';
 import API from '../api/client';
 import { formatDate, showToast } from '../utils/helpers';
 import SubmitPromptModal from '../components/SubmitPromptModal';
@@ -247,6 +248,17 @@ export default function JobDetail() {
     } catch (error) {
       console.error('Failed to restore segment:', error);
       const errorMessage = error.response?.data?.detail || error.message || 'Failed to restore segment';
+      showToast(errorMessage, 'error');
+    }
+  }
+
+  async function handleToggleFade(segmentIndex, currentValue) {
+    try {
+      await API.updateSegmentFade(id, segmentIndex, !currentValue);
+      await loadJobDetail();
+    } catch (error) {
+      console.error('Failed to update fade setting:', error);
+      const errorMessage = error.response?.data?.detail || error.message || 'Failed to update fade setting';
       showToast(errorMessage, 'error');
     }
   }
@@ -671,17 +683,20 @@ export default function JobDetail() {
             // For display: active segments get sequential numbers (1, 2, 3...)
             // Deleted segments show their original number with strikethrough
             const displayNumber = isDeleted ? seg.segment_index + 1 : ++activeCount;
-            // Can delete any non-deleted segment when job allows it
-            const canDelete = !isDeleted && (job.status === 'awaiting_prompt' || job.status === 'completed');
-            // Can restore deleted segments
-            const canRestore = isDeleted;
+            // Can delete any non-deleted segment when job is not finalized
+            const canDelete = !isDeleted && job.status === 'awaiting_prompt';
+            // Can restore deleted segments when job is not finalized
+            const canRestore = isDeleted && job.status === 'awaiting_prompt';
+
+            // Can toggle fade on completed, non-deleted segments when job is not finalized
+            const canToggleFade = !isDeleted && seg.status === 'completed' && job.status === 'awaiting_prompt';
 
             return (
-              <div
-                key={seg.id}
-                className="segment-item"
-                style={isDeleted ? { opacity: 0.5, backgroundColor: '#f5f5f5' } : {}}
-              >
+              <div key={seg.id}>
+                <div
+                  className="segment-item"
+                  style={isDeleted ? { opacity: 0.5, backgroundColor: '#f5f5f5' } : {}}
+                >
                 <div className="segment-header">
                   <div>
                     <strong style={isDeleted ? { textDecoration: 'line-through', color: '#999' } : {}}>
@@ -894,6 +909,56 @@ export default function JobDetail() {
                 </div>
               </div>
             </div>
+
+                {/* Transition Row - editable for non-finalized */}
+                {canToggleFade && (
+                  <div
+                    style={{
+                      padding: '12px 16px',
+                      border: '1px solid #e0e0e0',
+                      borderRadius: '4px',
+                      marginBottom: '12px',
+                      backgroundColor: '#fafafa',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: '8px'
+                    }}
+                  >
+                    <Checkbox
+                      checked={Number(seg.fade_to_black) === 1}
+                      onChange={() => handleToggleFade(seg.segment_index, Number(seg.fade_to_black) === 1)}
+                      size="small"
+                      sx={{ padding: '4px' }}
+                    />
+                    <SwitchVideoIcon sx={{ color: Number(seg.fade_to_black) === 1 ? '#ff9800' : '#999', fontSize: 20 }} />
+                    <span style={{ fontSize: '13px', color: Number(seg.fade_to_black) === 1 ? '#e65100' : '#666' }}>
+                      2 second fade transition
+                    </span>
+                  </div>
+                )}
+                {/* Read-only fade indicator for finalized jobs */}
+                {!canToggleFade && seg.status === 'completed' && !isDeleted && job.status === 'completed' && Number(seg.fade_to_black) === 1 && (
+                  <div
+                    style={{
+                      padding: '12px 16px',
+                      border: '1px solid #e0e0e0',
+                      borderRadius: '4px',
+                      marginBottom: '12px',
+                      backgroundColor: '#fafafa',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: '8px'
+                    }}
+                  >
+                    <SwitchVideoIcon sx={{ color: '#ff9800', fontSize: 20 }} />
+                    <span style={{ fontSize: '13px', color: '#e65100' }}>
+                      2 second fade transition
+                    </span>
+                  </div>
+                )}
+              </div>
             );
           });
         })()}


### PR DESCRIPTION
- Add fade_to_black column to job_segments table
- Add API endpoint PUT /jobs/{id}/segments/{idx}/fade to toggle fade
- Implement fade-in/fade-out effects in video_utils.py using ffmpeg
- When segment has fade enabled: fade out at end, fade in on next segment
- Add transition row UI in JobDetail with SwitchVideoIcon
- Show editable checkbox for non-finalized jobs
- Show read-only indicator for finalized jobs with fade enabled
- Restrict delete/restore/fade toggle to awaiting_prompt status only