### PR TITLE
Add Avg Run Time dashboard card (#88)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -428,6 +428,46 @@ def get_all_jobs(limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
         return [_row_to_job_dict(row) for row in cursor.fetchall()]
 
 
+def get_avg_run_time(num_jobs: int = 5) -> Optional[float]:
+    """Calculate average total run time from the last N completed jobs.
+
+    Args:
+        num_jobs: Number of recent completed jobs to average (default 5)
+
+    Returns:
+        Average run time in seconds, or None if no completed jobs
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        # Get the last N completed jobs
+        cursor.execute(
+            "SELECT id FROM jobs WHERE status = 'completed' ORDER BY completed_at DESC LIMIT ?",
+            (num_jobs,)
+        )
+        job_ids = [row[0] for row in cursor.fetchall()]
+
+        if not job_ids:
+            return None
+
+        # Sum execution_time for all completed segments of these jobs
+        placeholders = ','.join('?' * len(job_ids))
+        cursor.execute(f"""
+            SELECT job_id, SUM(execution_time) as total_time
+            FROM job_segments
+            WHERE job_id IN ({placeholders})
+              AND status = 'completed'
+              AND execution_time IS NOT NULL
+            GROUP BY job_id
+        """, job_ids)
+
+        totals = [row[1] for row in cursor.fetchall() if row[1] is not None]
+
+        if not totals:
+            return None
+
+        return sum(totals) / len(totals)
+
+
 def get_pending_jobs() -> List[Dict[str, Any]]:
     """Get all pending jobs ordered by priority (lower number = higher priority)."""
     with get_connection() as conn:

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -18,6 +18,7 @@ from video_utils import get_segment_video_path, optimize_video_for_web
 
 from database import (
     get_all_jobs,
+    get_avg_run_time,
     get_job,
     create_job,
     delete_job,
@@ -334,12 +335,21 @@ class QueueStatus(BaseModel):
 
 # ============== Job Endpoints ==============
 
-@router.get("/jobs", response_model=List[JobResponse])
+@router.get("/jobs")
 async def list_jobs(limit: int = 100, offset: int = 0):
-    """Get all jobs with pagination, enriched with segment counts."""
+    """Get all jobs with pagination, enriched with segment counts.
+
+    Returns:
+        Object with jobs list and avg_run_time (average run time of last 5 completed jobs in seconds)
+    """
     jobs = get_all_jobs(limit=limit, offset=offset)
-    # Enrich each job with segment counts
-    return [enrich_job_with_segments(job) for job in jobs]
+    enriched_jobs = [enrich_job_with_segments(job) for job in jobs]
+    avg_time = get_avg_run_time(num_jobs=5)
+
+    return {
+        "jobs": enriched_jobs,
+        "avg_run_time": avg_time  # in seconds, or None if no completed jobs
+    }
 
 
 @router.get("/jobs/{job_id}", response_model=JobResponse)

--- a/react-app/src/pages/Dashboard.jsx
+++ b/react-app/src/pages/Dashboard.jsx
@@ -28,6 +28,7 @@ export default function Dashboard() {
   const [runningJobsCount, setRunningJobsCount] = useState(0);
   const [pendingJobsCount, setPendingJobsCount] = useState(0);
   const [awaitingPromptJobsCount, setAwaitingPromptJobsCount] = useState(0);
+  const [avgRunTime, setAvgRunTime] = useState(null);
   const [allJobs, setAllJobs] = useState([]);
   const [filteredJobs, setFilteredJobs] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -75,6 +76,7 @@ export default function Dashboard() {
       setRunningJobsCount(jobs.filter(j => j.status === 'running').length);
       setPendingJobsCount(jobs.filter(j => j.status === 'pending').length);
       setAwaitingPromptJobsCount(jobs.filter(j => j.status === 'awaiting_prompt').length);
+      setAvgRunTime(jobsData.avg_run_time);
 
       setAllJobs(jobs);
       setLoading(false);
@@ -166,6 +168,13 @@ export default function Dashboard() {
     return 'Connected - Idle';
   }
 
+  function formatRunTime(seconds) {
+    if (seconds == null) return 'N/A';
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.round(seconds % 60);
+    return `${mins}m ${secs}s`;
+  }
+
   if (loading) {
     return (
       <div>
@@ -205,6 +214,11 @@ export default function Dashboard() {
         <div className="card">
           <h3>Awaiting Prompt</h3>
           <div className="value">{awaitingPromptJobsCount}</div>
+        </div>
+
+        <div className="card">
+          <h3>Avg Run Time</h3>
+          <div className="value">{formatRunTime(avgRunTime)}</div>
         </div>
       </div>
 


### PR DESCRIPTION
- Add get_avg_run_time() function to calculate average total run time from last 5 completed jobs
- Update /jobs endpoint to return avg_run_time alongside jobs list
- Add Avg Run Time card to Dashboard displaying time in Xm Ys format