### PR TITLE
Add custom start image selection for segments (#44)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -216,6 +216,12 @@ def init_db():
         except sqlite3.OperationalError:
             pass  # Column already exists
 
+        # Add custom_start_image column for overriding default start image
+        try:
+            cursor.execute("ALTER TABLE job_segments ADD COLUMN custom_start_image TEXT")
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
         # Add priority column for queue ordering (lower number = higher priority)
         try:
             cursor.execute("ALTER TABLE jobs ADD COLUMN priority INTEGER DEFAULT 0")
@@ -1048,7 +1054,8 @@ def create_next_segment(
     faceswap_image: Optional[str] = None,
     faceswap_faces_order: str = "left-right",
     faceswap_faces_index: str = "0",
-    fade_to_black: bool = False
+    fade_to_black: bool = False,
+    custom_start_image: Optional[str] = None
 ):
     """Create the next segment for a job (on-demand workflow).
 
@@ -1066,18 +1073,19 @@ def create_next_segment(
         faceswap_faces_order: Order to process faces (left-right, right-left, etc.)
         faceswap_faces_index: Which face indices to process (e.g., "0", "0,1")
         fade_to_black: Whether to apply fade-to-black transition at segment end
+        custom_start_image: Optional path to custom start image from image repo (overrides default)
     """
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute("""
             INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora,
                                       faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index,
-                                      fade_to_black)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                      fade_to_black, custom_start_image)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, segment_index, prompt, start_image_url,
               serialize_loras(high_loras), serialize_loras(low_loras),
               1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index,
-              1 if fade_to_black else 0))
+              1 if fade_to_black else 0, custom_start_image))
 
 
 def create_segments_for_job(
@@ -1253,7 +1261,8 @@ def update_segment_prompt(
     faceswap_image: Optional[str] = None,
     faceswap_faces_order: Optional[str] = None,
     faceswap_faces_index: Optional[str] = None,
-    fade_to_black: Optional[bool] = None
+    fade_to_black: Optional[bool] = None,
+    custom_start_image: Optional[str] = None
 ):
     """Update a segment's prompt and optionally its LoRA and faceswap settings.
 
@@ -1268,6 +1277,8 @@ def update_segment_prompt(
         faceswap_faces_order: Faces order, or None to not update
         faceswap_faces_index: Faces index, or None to not update
         fade_to_black: Whether to apply fade-to-black transition at segment end, or None to not update
+        custom_start_image: Path to custom start image from image repo, or None to not update.
+                           Use empty string to clear custom image and revert to default.
     """
     with get_connection() as conn:
         cursor = conn.cursor()
@@ -1302,6 +1313,11 @@ def update_segment_prompt(
         if fade_to_black is not None:
             updates.append("fade_to_black = ?")
             params.append(1 if fade_to_black else 0)
+
+        if custom_start_image is not None:
+            updates.append("custom_start_image = ?")
+            # Empty string means clear (revert to default), otherwise store the path
+            params.append(custom_start_image if custom_start_image else None)
 
         params.extend([job_id, segment_index])
 

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -6,6 +6,7 @@ import time
 import urllib.parse
 import json
 import logging
+from pathlib import Path
 from typing import Optional, Callable
 from datetime import datetime
 
@@ -450,7 +451,17 @@ class QueueManager:
         frames = fps * segment_duration + 1
         
         # Determine the start image for this segment
-        if segment_index == 0:
+        # Check for custom start image first (overrides default behavior)
+        custom_start_image = segment.get("custom_start_image")
+        if custom_start_image and segment_index > 0:
+            # Upload custom image from image repo to ComfyUI
+            input_image = self._upload_custom_start_image(custom_start_image, client)
+            if not input_image:
+                print(f"[QueueManager] Failed to upload custom start image for segment {segment_index}")
+                update_segment_status(job_id, segment_index, "failed", error_message="Failed to upload custom start image")
+                return False
+            print(f"[QueueManager] Segment {segment_index} using CUSTOM start image: {input_image}")
+        elif segment_index == 0:
             # First segment uses the job's input image
             input_image = job.get("input_image")
         else:
@@ -829,6 +840,71 @@ class QueueManager:
 
         progress_tracker.stop_tracking(job_id)
         return False
+
+    def _upload_custom_start_image(self, image_path: str, client: ComfyUIClient) -> Optional[str]:
+        """Upload a custom start image from the image repo to ComfyUI.
+
+        Args:
+            image_path: Path to the image within the image repo (relative path)
+            client: ComfyUI client instance
+
+        Returns:
+            The ComfyUI filename of the uploaded image, or None if upload failed
+        """
+        from database import compute_image_hash, get_image_by_hash, store_uploaded_image
+
+        repo_root = get_setting("image_repo_path", "")
+        if not repo_root:
+            print(f"[QueueManager] Image repository path not configured")
+            return None
+
+        repo_root_path = Path(repo_root)
+        full_path = (repo_root_path / image_path).resolve()
+
+        # Security: Ensure path is within repo root
+        if not str(full_path).startswith(str(repo_root_path.resolve())):
+            print(f"[QueueManager] Custom image path is outside repository: {image_path}")
+            return None
+
+        if not full_path.exists() or not full_path.is_file():
+            print(f"[QueueManager] Custom image not found: {full_path}")
+            return None
+
+        # Check file extension
+        if full_path.suffix.lower() not in ['.jpg', '.jpeg', '.png']:
+            print(f"[QueueManager] Unsupported image format: {full_path.suffix}")
+            return None
+
+        try:
+            # Read the image file
+            with open(full_path, 'rb') as f:
+                image_content = f.read()
+
+            # Check if this image was already uploaded (by content hash)
+            content_hash = compute_image_hash(image_content)
+            existing = get_image_by_hash(content_hash)
+
+            if existing:
+                # Image already exists, return existing filename without re-uploading
+                print(f"[QueueManager] Custom image already in ComfyUI (deduplicated): {existing['comfyui_filename']}")
+                return existing['comfyui_filename']
+
+            # Upload to ComfyUI
+            result_filename = client.upload_image(image_content, full_path.name)
+
+            if not result_filename:
+                print(f"[QueueManager] Failed to upload custom image to ComfyUI")
+                return None
+
+            # Store the hash for future deduplication
+            store_uploaded_image(content_hash, result_filename, full_path.name)
+
+            print(f"[QueueManager] Uploaded custom start image: {result_filename}")
+            return result_filename
+
+        except Exception as e:
+            print(f"[QueueManager] Error uploading custom start image: {e}")
+            return None
 
     def _finalize_job(self, job_id: int):
         """Finalize a job by stitching all completed (non-deleted) segment videos together."""

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -833,7 +833,8 @@ async def update_segment_prompt_endpoint(
     faceswap_image: Optional[str] = Form(None),  # Face image filename
     faceswap_faces_order: Optional[str] = Form("left-right"),  # Faces order
     faceswap_faces_index: Optional[str] = Form("0"),  # Faces index
-    fade_to_black: Optional[bool] = Form(False)  # Apply fade-to-black transition at segment end
+    fade_to_black: Optional[bool] = Form(False),  # Apply fade-to-black transition at segment end
+    custom_start_image: Optional[str] = Form(None)  # Custom start image path from image repo
 ):
     """Create or update a segment with a prompt and resume job processing (on-demand workflow).
 
@@ -846,6 +847,7 @@ async def update_segment_prompt_endpoint(
         faceswap_faces_order: Order to process faces (left-right, right-left, etc.).
         faceswap_faces_index: Which face indices to process (e.g., "0", "0,1").
         fade_to_black: Apply fade-to-black transition at the end of this segment.
+        custom_start_image: Path to custom start image from image repo (overrides default).
     """
     job = get_job(job_id)
     if not job:
@@ -926,7 +928,8 @@ async def update_segment_prompt_endpoint(
             faceswap_image=faceswap_image or "",
             faceswap_faces_order=faceswap_faces_order or "left-right",
             faceswap_faces_index=faceswap_faces_index or "0",
-            fade_to_black=fade_to_black or False
+            fade_to_black=fade_to_black or False,
+            custom_start_image=custom_start_image
         )
     else:
         # Segment exists - update its prompt, LoRA, and faceswap settings
@@ -938,7 +941,8 @@ async def update_segment_prompt_endpoint(
             faceswap_image=faceswap_image,
             faceswap_faces_order=faceswap_faces_order,
             faceswap_faces_index=faceswap_faces_index,
-            fade_to_black=fade_to_black
+            fade_to_black=fade_to_black,
+            custom_start_image=custom_start_image
         )
 
     # Update auto_finalize in job parameters

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -215,7 +215,7 @@ class APIClient {
     return `${API_BASE_URL}/jobs/${jobId}/segments/${segmentIndex}/video`;
   }
 
-  async submitSegmentPrompt(jobId, segmentIndex, prompt, loras = [], autoFinalize = false, faceswapOptions = null, fadeToBlack = false) {
+  async submitSegmentPrompt(jobId, segmentIndex, prompt, loras = [], autoFinalize = false, faceswapOptions = null, fadeToBlack = false, customStartImage = null) {
     const formData = new FormData();
     formData.append('prompt', prompt);
 
@@ -248,6 +248,11 @@ class APIClient {
       formData.append('faceswap_image', faceswapOptions.image || '');
       formData.append('faceswap_faces_order', faceswapOptions.facesOrder || 'left-right');
       formData.append('faceswap_faces_index', faceswapOptions.facesIndex || '0');
+    }
+
+    // Custom start image (overrides default previous segment's last frame)
+    if (customStartImage) {
+      formData.append('custom_start_image', customStartImage);
     }
 
     return this.request(`/jobs/${jobId}/segments/${segmentIndex}/prompt`, {

--- a/react-app/src/components/ImageRepoBrowserModal.jsx
+++ b/react-app/src/components/ImageRepoBrowserModal.jsx
@@ -1,0 +1,191 @@
+import { useState, useEffect } from 'react';
+import { CircularProgress, Button } from '@mui/material';
+import API from '../api/client';
+import './CreateJobModal.css';
+
+export default function ImageRepoBrowserModal({ onSelect, onClose }) {
+  const [currentPath, setCurrentPath] = useState('');
+  const [folders, setFolders] = useState([]);
+  const [images, setImages] = useState([]);
+  const [breadcrumbs, setBreadcrumbs] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    loadDirectory(currentPath);
+  }, [currentPath]);
+
+  async function loadDirectory(path) {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await API.browseImageRepo(path);
+
+      // Sort folders alphabetically, with date folders (YYYY-MM-DD) newest first
+      const sortedFolders = (data.folders || []).sort((a, b) => {
+        const datePatternA = a.name.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        const datePatternB = b.name.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (datePatternA && datePatternB) {
+          return b.name.localeCompare(a.name); // Newest first
+        }
+        return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+      });
+
+      // Sort images alphabetically
+      const sortedImages = (data.images || []).sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      );
+
+      setFolders(sortedFolders);
+      setImages(sortedImages);
+      setBreadcrumbs(data.breadcrumbs || []);
+      setLoading(false);
+    } catch (err) {
+      console.error('Failed to load image repository:', err);
+      setError(err.message || 'Failed to load directory');
+      setLoading(false);
+    }
+  }
+
+  function handleFolderClick(folder) {
+    setCurrentPath(folder.path);
+  }
+
+  function handleImageClick(image) {
+    onSelect(image.path);
+  }
+
+  function navigateToPath(path) {
+    setCurrentPath(path);
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content" style={{ maxWidth: '800px', maxHeight: '80vh', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <button type="button" className="modal-close" onClick={onClose}>x</button>
+        <h2 style={{ marginTop: 0, marginBottom: '16px' }}>Select Start Image</h2>
+
+        {/* Breadcrumb navigation */}
+        <div style={{ marginBottom: '16px', padding: '8px', background: '#f5f5f5', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+          {breadcrumbs.map((crumb, index) => {
+            const isLast = index === breadcrumbs.length - 1;
+            return (
+              <span key={index}>
+                <span
+                  onClick={isLast ? undefined : () => navigateToPath(crumb.path)}
+                  style={{
+                    cursor: isLast ? 'default' : 'pointer',
+                    color: isLast ? '#333' : '#1976d2',
+                    fontWeight: isLast ? 'bold' : 'normal'
+                  }}
+                >
+                  {crumb.name}
+                </span>
+                {!isLast && <span style={{ margin: '0 4px', color: '#999' }}>/</span>}
+              </span>
+            );
+          })}
+        </div>
+
+        {/* Content area */}
+        <div style={{ flex: 1, overflow: 'auto', minHeight: '300px' }}>
+          {loading && (
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '40px' }}>
+              <CircularProgress />
+            </div>
+          )}
+
+          {error && (
+            <div style={{ color: '#d32f2f', padding: '16px', background: '#ffebee', borderRadius: '4px' }}>
+              {error}
+            </div>
+          )}
+
+          {!loading && !error && (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '12px' }}>
+              {/* Folders */}
+              {folders.map(folder => (
+                <div
+                  key={folder.path}
+                  onClick={() => handleFolderClick(folder)}
+                  style={{
+                    cursor: 'pointer',
+                    padding: '8px',
+                    border: '1px solid #e0e0e0',
+                    borderRadius: '8px',
+                    textAlign: 'center',
+                    background: '#fafafa',
+                    transition: 'background 0.2s'
+                  }}
+                  onMouseOver={(e) => e.currentTarget.style.background = '#e3f2fd'}
+                  onMouseOut={(e) => e.currentTarget.style.background = '#fafafa'}
+                >
+                  <div style={{ fontSize: '32px', marginBottom: '4px' }}>
+                    {folder.preview_images?.length > 0 ? (
+                      <img
+                        src={API.getRepoImage(folder.preview_images[0])}
+                        alt=""
+                        style={{ width: '80px', height: '80px', objectFit: 'cover', borderRadius: '4px' }}
+                        onError={(e) => { e.target.style.display = 'none'; e.target.nextSibling.style.display = 'block'; }}
+                      />
+                    ) : null}
+                    <span style={{ display: folder.preview_images?.length > 0 ? 'none' : 'block' }}>&#x1F4C1;</span>
+                  </div>
+                  <div style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {folder.name}
+                  </div>
+                </div>
+              ))}
+
+              {/* Images - large preview with clear aspect ratio */}
+              {images.map(image => (
+                <div
+                  key={image.path}
+                  onClick={() => handleImageClick(image)}
+                  style={{
+                    cursor: 'pointer',
+                    border: '2px solid #e0e0e0',
+                    borderRadius: '8px',
+                    overflow: 'hidden',
+                    transition: 'border-color 0.2s, transform 0.2s',
+                    background: '#222'
+                  }}
+                  onMouseOver={(e) => { e.currentTarget.style.borderColor = '#1976d2'; e.currentTarget.style.transform = 'scale(1.02)'; }}
+                  onMouseOut={(e) => { e.currentTarget.style.borderColor = '#e0e0e0'; e.currentTarget.style.transform = 'scale(1)'; }}
+                >
+                  <div style={{ height: '180px', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '4px' }}>
+                    <img
+                      src={API.getRepoImage(image.path)}
+                      alt={image.name}
+                      style={{ maxWidth: '100%', maxHeight: '172px', objectFit: 'contain', borderRadius: '4px' }}
+                      onError={(e) => {
+                        e.target.src = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22100%22 height=%22100%22%3E%3Crect fill=%22%23ddd%22 width=%22100%22 height=%22100%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 fill=%22%23999%22%3E?%3C/text%3E%3C/svg%3E';
+                      }}
+                    />
+                  </div>
+                  <div style={{ padding: '4px', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', background: '#fafafa' }}>
+                    {image.name}
+                  </div>
+                </div>
+              ))}
+
+              {folders.length === 0 && images.length === 0 && (
+                <div style={{ gridColumn: '1 / -1', textAlign: 'center', color: '#999', padding: '40px' }}>
+                  This directory is empty
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div style={{ marginTop: '16px', display: 'flex', justifyContent: 'flex-end' }}>
+          <Button variant="outlined" onClick={onClose}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/react-app/src/components/SubmitPromptModal.jsx
+++ b/react-app/src/components/SubmitPromptModal.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
-import { Button, TextField, FormControlLabel, Checkbox, FormHelperText, CircularProgress, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { Button, TextField, FormControlLabel, Checkbox, FormHelperText, CircularProgress, FormControl, InputLabel, Select, MenuItem, IconButton, Tooltip } from '@mui/material';
+import RestoreIcon from '@mui/icons-material/Restore';
 import API from '../api/client';
 import { showToast } from '../utils/helpers';
 import LoraAutocomplete from './LoraAutocomplete';
+import ImageRepoBrowserModal from './ImageRepoBrowserModal';
 import './CreateJobModal.css';
 
 // Available face swap images (in ComfyUI input folder)
@@ -25,6 +27,7 @@ export default function SubmitPromptModal({
   defaultPrompt = '',
   defaultLoras = [],  // Array of {high_file, high_weight, low_file, low_weight} pairs
   defaultFaceswap = null,  // {enabled, image, facesOrder, facesIndex} from previous segment or job
+  defaultStartImageUrl = null,  // URL of previous segment's end frame (for display)
   onClose,
   onSuccess
 }) {
@@ -44,6 +47,10 @@ export default function SubmitPromptModal({
   const [faceswapImage, setFaceswapImage] = useState(defaultFaceswap?.image || FACESWAP_FACES[0]?.value || '');
   const [faceswapFacesOrder, setFaceswapFacesOrder] = useState(defaultFaceswap?.facesOrder || 'left-right');
   const [faceswapFacesIndex, setFaceswapFacesIndex] = useState(defaultFaceswap?.facesIndex || '0');
+
+  // Custom start image state (only for segments > 0)
+  const [customStartImage, setCustomStartImage] = useState(null);  // Path in image repo
+  const [showImageBrowser, setShowImageBrowser] = useState(false);
 
   useEffect(() => {
     loadLoras();
@@ -172,7 +179,9 @@ export default function SubmitPromptModal({
         prompt.trim(),
         lorasArray,
         autoFinalize,
-        faceswapOptions
+        faceswapOptions,
+        false,  // fadeToBlack - not used here
+        customStartImage  // Custom start image path (or null for default)
       );
 
       showToast('Prompt submitted successfully', 'success');
@@ -189,6 +198,60 @@ export default function SubmitPromptModal({
       <div className="modal-content">
         <button type="button" className="modal-close" onClick={onClose}>×</button>
         <h2>Submit Prompt for Segment {segmentIndex}</h2>
+
+        {/* Start Image Selection (only for segments > 0) */}
+        {segmentIndex > 0 && defaultStartImageUrl && (
+          <div style={{ marginBottom: '16px', padding: '12px', background: '#f5f5f5', borderRadius: '8px', border: '1px solid #e0e0e0' }}>
+            <div style={{ fontSize: '13px', fontWeight: 500, marginBottom: '8px', color: '#666' }}>Start Image</div>
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
+              <img
+                src={customStartImage ? API.getRepoImage(customStartImage) : defaultStartImageUrl}
+                alt="Start frame"
+                style={{
+                  width: '120px',
+                  height: '80px',
+                  objectFit: 'cover',
+                  borderRadius: '4px',
+                  border: customStartImage ? '2px solid #1976d2' : '1px solid #ddd'
+                }}
+                onError={(e) => { e.target.style.display = 'none'; }}
+              />
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: '12px', color: customStartImage ? '#1976d2' : '#666', marginBottom: '4px' }}>
+                  {customStartImage ? 'Custom image selected' : 'Using previous segment\'s last frame'}
+                </div>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                  <button
+                    type="button"
+                    onClick={() => setShowImageBrowser(true)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#1976d2',
+                      cursor: 'pointer',
+                      fontSize: '12px',
+                      padding: 0,
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    {customStartImage ? 'Change image' : 'Choose different image'}
+                  </button>
+                  {customStartImage && (
+                    <Tooltip title="Revert to previous segment's last frame">
+                      <IconButton
+                        size="small"
+                        onClick={() => setCustomStartImage(null)}
+                        sx={{ padding: '2px' }}
+                      >
+                        <RestoreIcon sx={{ fontSize: 18, color: '#666' }} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {defaultPrompt && (
           <div style={{ marginBottom: '16px', padding: '12px', background: '#e3f2fd', borderRadius: '4px', border: '1px solid #90caf9' }}>
@@ -450,6 +513,17 @@ export default function SubmitPromptModal({
           </div>
         </form>
       </div>
+
+      {/* Image Browser Modal for custom start image selection */}
+      {showImageBrowser && (
+        <ImageRepoBrowserModal
+          onSelect={(imagePath) => {
+            setCustomStartImage(imagePath);
+            setShowImageBrowser(false);
+          }}
+          onClose={() => setShowImageBrowser(false)}
+        />
+      )}
     </div>
   );
 }

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -741,8 +741,22 @@ export default function JobDetail() {
               <div className="segment-content">
                 {/* Start Image */}
                 <div className="segment-image-container">
-                  <div className="segment-image-label">Start Image</div>
-                  {seg.start_image_url ? (
+                  <div className="segment-image-label">
+                    Start Image
+                    {seg.custom_start_image && (
+                      <span style={{ marginLeft: '6px', fontSize: '10px', color: '#1976d2', fontWeight: 'normal' }}>(custom)</span>
+                    )}
+                  </div>
+                  {seg.custom_start_image ? (
+                    <img
+                      src={API.getRepoImage(seg.custom_start_image)}
+                      alt="Custom start image"
+                      className="segment-image start clickable"
+                      style={{ border: '2px solid #1976d2' }}
+                      onClick={() => setLightboxImage(API.getRepoImage(seg.custom_start_image))}
+                      onError={(e) => e.target.style.display = 'none'}
+                    />
+                  ) : seg.start_image_url ? (
                     <img
                       src={seg.start_image_url}
                       alt={seg.start_image_url}
@@ -1105,6 +1119,7 @@ export default function JobDetail() {
           defaultPrompt={lastCompletedSegment?.prompt || ''}
           defaultLoras={buildDefaultLoras(lastCompletedSegment)}
           defaultFaceswap={buildDefaultFaceswap(lastCompletedSegment, job?.parameters)}
+          defaultStartImageUrl={lastCompletedSegment?.end_frame_url || null}
           onClose={() => setShowPromptModal(false)}
           onSuccess={() => {
             setShowPromptModal(false);


### PR DESCRIPTION
- Add custom_start_image column to job_segments table
- Add image repo browser modal for selecting custom start images
- Update SubmitPromptModal to show start image with change option (segments 2+)
- Update queue_manager to upload and use custom start images from image repo
- Display custom start images in segment timeline with "(custom)" label and blue border
- Image browser shows larger previews with dark background for clear orientation