### PR TITLE
Add 3 LoRA support and redesign modals (#114)

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -269,7 +269,7 @@ class JobCreate(BaseModel):
     workflow_type: Optional[str] = "txt2img"
     parameters: Optional[Dict[str, Any]] = None
     input_image: Optional[str] = None  # Base64 encoded or ComfyUI filename
-    loras: Optional[List[LoraSelection]] = None  # 0-2 LoRA pairs
+    loras: Optional[List[LoraSelection]] = None  # 0-3 LoRA pairs
 
 
 class JobUpdate(BaseModel):
@@ -456,11 +456,11 @@ async def create_new_job(job: JobCreate):
         else:
             start_image_url = f"{comfyui_url}/view?filename={job.input_image}&subfolder=&type=input"
 
-    # Extract LoRA selections from loras list (0-2 pairs) with weights
+    # Extract LoRA selections from loras list (0-3 pairs) with weights
     high_loras = []
     low_loras = []
     if job.loras:
-        for lora in job.loras[:2]:  # Max 2 pairs
+        for lora in job.loras[:3]:  # Max 3 pairs
             if lora.high_file or lora.low_file:
                 if lora.high_file:
                     high_loras.append({
@@ -887,7 +887,7 @@ async def update_segment_prompt_endpoint(
     if loras:
         try:
             lora_list = json.loads(loras)
-            for lora in lora_list[:2]:  # Max 2 pairs
+            for lora in lora_list[:3]:  # Max 3 pairs
                 if lora.get("high_file") or lora.get("low_file"):
                     # Store as objects with file and weight
                     if lora.get("high_file"):

--- a/backend/workflow_templates.py
+++ b/backend/workflow_templates.py
@@ -180,10 +180,10 @@ WAN_I2V_API_WORKFLOW = {
 }
 
 
-# LoRA node IDs for dynamic creation (high pass: 118, 120; low pass: 119, 121)
+# LoRA node IDs for dynamic creation (high pass: 118, 120, 122; low pass: 119, 121, 123)
 LORA_NODE_IDS = {
-    "high": ["118", "120"],  # First LoRA high, Second LoRA high
-    "low": ["119", "121"],   # First LoRA low, Second LoRA low
+    "high": ["118", "120", "122"],  # First, Second, Third LoRA high
+    "low": ["119", "121", "123"],   # First, Second, Third LoRA low
 }
 
 
@@ -228,7 +228,7 @@ def build_wan_i2v_workflow(
         high_noise_model: UNET model for high noise pass
         low_noise_model: UNET model for low noise pass
         seed: Random seed (auto-generated if not provided)
-        loras: Optional list of LoRA pairs (max 2). Each dict has:
+        loras: Optional list of LoRA pairs (max 3). Each dict has:
                - high_file: LoRA filename for high noise pass
                - low_file: LoRA filename for low noise pass
                If empty/None, no user LoRAs are applied (only lightx2v acceleration)
@@ -278,8 +278,8 @@ def build_wan_i2v_workflow(
     workflow["86"]["inputs"]["noise_seed"] = seed
     print(f"[Workflow] Set seed: {seed}")
 
-    # Add user-selected LoRA nodes dynamically (0-2 pairs)
-    # Chain: UNET -> LoRA1 -> LoRA2 -> lightx2v
+    # Add user-selected LoRA nodes dynamically (0-3 pairs)
+    # Chain: UNET -> LoRA1 -> LoRA2 -> LoRA3 -> lightx2v
     # If no LoRAs: UNET -> lightx2v (already wired in template)
     # Each lora dict can have: high_file, high_weight, low_file, low_weight
     loras = loras or []
@@ -292,7 +292,7 @@ def build_wan_i2v_workflow(
         last_high_node = "95"  # UNET high
         last_low_node = "96"   # UNET low
 
-        for i, lora in enumerate(loras[:2]):  # Max 2 pairs
+        for i, lora in enumerate(loras[:3]):  # Max 3 pairs
             high_file = lora.get("high_file")
             high_weight = float(lora.get("high_weight", 1.0))
             low_file = lora.get("low_file")

--- a/react-app/src/components/CreateJobModal.css
+++ b/react-app/src/components/CreateJobModal.css
@@ -13,34 +13,92 @@
 
 .modal-content {
   background: white;
-  padding: 24px;
   border-radius: 8px;
-  max-width: 600px;
-  width: 90%;
+  max-width: 900px;
+  width: 95%;
   max-height: 95vh;
-  overflow-y: auto;
-  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  background: #1976d2;
+  color: white;
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 500;
 }
 
 .modal-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
   background: none;
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: #666;
+  color: white;
   padding: 4px 8px;
   line-height: 1;
+  opacity: 0.8;
 }
 
 .modal-close:hover {
-  color: #333;
+  opacity: 1;
 }
 
-.modal-content h2 {
-  margin-top: 0;
+.modal-body {
+  padding: 24px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.modal-footer {
+  background: #f5f5f5;
+  padding: 16px 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+  border-top: 1px solid #e0e0e0;
+}
+
+.lora-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.lora-slot {
+  padding: 12px;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+}
+
+.lora-slot-header {
+  font-size: 13px;
+  font-weight: 500;
+  color: #666;
+  margin-bottom: 8px;
+}
+
+.lora-weights {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.lora-weights .MuiTextField-root {
+  flex: 1;
 }
 
 .form-group {

--- a/react-app/src/components/CreateJobModal.jsx
+++ b/react-app/src/components/CreateJobModal.jsx
@@ -34,8 +34,9 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
   const [segmentDuration, setSegmentDuration] = useState(5);
   const [imageFile, setImageFile] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
-  // Two LoRA slots, each with lora object and weights
+  // Three LoRA slots, each with lora object and weights
   const [selectedLoras, setSelectedLoras] = useState([
+    { lora: null, highWeight: 1, lowWeight: 1 },
     { lora: null, highWeight: 1, lowWeight: 1 },
     { lora: null, highWeight: 1, lowWeight: 1 }
   ]);
@@ -135,10 +136,11 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
       // Find matching LoRAs for each slot with weights
       const newSelectedLoras = [
         { lora: null, highWeight: 1, lowWeight: 1 },
+        { lora: null, highWeight: 1, lowWeight: 1 },
         { lora: null, highWeight: 1, lowWeight: 1 }
       ];
 
-      for (let idx = 0; idx < 2; idx++) {
+      for (let idx = 0; idx < 3; idx++) {
         const highData = highLoraData[idx];
         const lowData = lowLoraData[idx];
 
@@ -159,7 +161,7 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
         }
       }
 
-      if (newSelectedLoras[0].lora || newSelectedLoras[1].lora) {
+      if (newSelectedLoras[0].lora || newSelectedLoras[1].lora || newSelectedLoras[2].lora) {
         setSelectedLoras(newSelectedLoras);
       }
     }
@@ -338,11 +340,13 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
 
   return (
     <div className="modal-overlay">
-      <div className="modal-content">
-        <button type="button" className="modal-close" onClick={onClose}>×</button>
-        <h2>{cloneData ? 'Clone Job' : 'Create New Video Job'}</h2>
+      <form className="modal-content" onSubmit={handleSubmit}>
+        <div className="modal-header">
+          <h2>{cloneData ? 'Clone Job' : 'Create New Video Job'}</h2>
+          <button type="button" className="modal-close" onClick={onClose}>×</button>
+        </div>
 
-        <form onSubmit={handleSubmit}>
+        <div className="modal-body">
           {(namePrefixes.length > 0 || nameDescriptions.length > 0) && (
             <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
               <Autocomplete
@@ -482,7 +486,7 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               multiline
-              height={"100px"}
+              rows={2}
               placeholder="Describe the video scene and action..."
               fullWidth
               variant="outlined"
@@ -527,132 +531,72 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
             )}
           </div>
 
-          {/* LoRA 1 */}
-          <div className="form-group">
-            <label style={{ marginBottom: '8px', display: 'block' }}>LoRA 1 (optional)</label>
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
-              <div style={{ flex: 1 }}>
+          {/* LoRAs - 3 columns */}
+          <div className="lora-grid">
+            {[0, 1, 2].map((idx) => (
+              <div key={idx} className="lora-slot">
+                <div className="lora-slot-header">LoRA {idx + 1} (optional)</div>
                 <LoraAutocomplete
                   label=""
-                  value={selectedLoras[0].lora}
-                  onChange={(lora) => setSelectedLoras([
-                    {
+                  value={selectedLoras[idx].lora}
+                  onChange={(lora) => {
+                    const newLoras = [...selectedLoras];
+                    newLoras[idx] = {
                       lora,
                       highWeight: lora?.default_high_weight ?? 1,
                       lowWeight: lora?.default_low_weight ?? 1
-                    },
-                    selectedLoras[1]
-                  ])}
+                    };
+                    setSelectedLoras(newLoras);
+                  }}
                   loras={loras}
                 />
-                <button
-                  type="button"
-                  onClick={() => appendLoraPrompt(selectedLoras[0].lora)}
-                  disabled={!selectedLoras[0].lora || !getLoraPromptText(selectedLoras[0].lora)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: selectedLoras[0].lora && getLoraPromptText(selectedLoras[0].lora) ? '#1976d2' : '#ccc',
-                    cursor: selectedLoras[0].lora && getLoraPromptText(selectedLoras[0].lora) ? 'pointer' : 'default',
-                    fontSize: '12px',
-                    padding: '4px 0',
-                    textDecoration: 'underline'
-                  }}
-                >
-                  + Add prompt
-                </button>
+                <div className="lora-weights">
+                  <TextField
+                    type="number"
+                    label="High"
+                    size="small"
+                    value={selectedLoras[idx].highWeight}
+                    onChange={(e) => {
+                      const newLoras = [...selectedLoras];
+                      newLoras[idx] = { ...newLoras[idx], highWeight: parseFloat(e.target.value) || 0 };
+                      setSelectedLoras(newLoras);
+                    }}
+                    inputProps={{ min: 0, max: 2, step: 0.1 }}
+                    disabled={!selectedLoras[idx].lora}
+                  />
+                  <TextField
+                    type="number"
+                    label="Low"
+                    size="small"
+                    value={selectedLoras[idx].lowWeight}
+                    onChange={(e) => {
+                      const newLoras = [...selectedLoras];
+                      newLoras[idx] = { ...newLoras[idx], lowWeight: parseFloat(e.target.value) || 0 };
+                      setSelectedLoras(newLoras);
+                    }}
+                    inputProps={{ min: 0, max: 2, step: 0.1 }}
+                    disabled={!selectedLoras[idx].lora}
+                  />
+                </div>
+                {selectedLoras[idx].lora && getLoraPromptText(selectedLoras[idx].lora) && (
+                  <button
+                    type="button"
+                    onClick={() => appendLoraPrompt(selectedLoras[idx].lora)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#1976d2',
+                      cursor: 'pointer',
+                      fontSize: '11px',
+                      padding: '4px 0 0 0',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    + Add prompt
+                  </button>
+                )}
               </div>
-              <TextField
-                type="number"
-                label="High"
-                size="small"
-                value={selectedLoras[0].highWeight}
-                onChange={(e) => setSelectedLoras([
-                  { ...selectedLoras[0], highWeight: parseFloat(e.target.value) || 0 },
-                  selectedLoras[1]
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[0].lora}
-              />
-              <TextField
-                type="number"
-                label="Low"
-                size="small"
-                value={selectedLoras[0].lowWeight}
-                onChange={(e) => setSelectedLoras([
-                  { ...selectedLoras[0], lowWeight: parseFloat(e.target.value) || 0 },
-                  selectedLoras[1]
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[0].lora}
-              />
-            </div>
-          </div>
-
-          {/* LoRA 2 */}
-          <div className="form-group">
-            <label style={{ marginBottom: '8px', display: 'block' }}>LoRA 2 (optional)</label>
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
-              <div style={{ flex: 1 }}>
-                <LoraAutocomplete
-                  label=""
-                  value={selectedLoras[1].lora}
-                  onChange={(lora) => setSelectedLoras([
-                    selectedLoras[0],
-                    {
-                      lora,
-                      highWeight: lora?.default_high_weight ?? 1,
-                      lowWeight: lora?.default_low_weight ?? 1
-                    }
-                  ])}
-                  loras={loras}
-                />
-                <button
-                  type="button"
-                  onClick={() => appendLoraPrompt(selectedLoras[1].lora)}
-                  disabled={!selectedLoras[1].lora || !getLoraPromptText(selectedLoras[1].lora)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: selectedLoras[1].lora && getLoraPromptText(selectedLoras[1].lora) ? '#1976d2' : '#ccc',
-                    cursor: selectedLoras[1].lora && getLoraPromptText(selectedLoras[1].lora) ? 'pointer' : 'default',
-                    fontSize: '12px',
-                    padding: '4px 0',
-                    textDecoration: 'underline'
-                  }}
-                >
-                  + Add prompt
-                </button>
-              </div>
-              <TextField
-                type="number"
-                label="High"
-                size="small"
-                value={selectedLoras[1].highWeight}
-                onChange={(e) => setSelectedLoras([
-                  selectedLoras[0],
-                  { ...selectedLoras[1], highWeight: parseFloat(e.target.value) || 0 }
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[1].lora}
-              />
-              <TextField
-                type="number"
-                label="Low"
-                size="small"
-                value={selectedLoras[1].lowWeight}
-                onChange={(e) => setSelectedLoras([
-                  selectedLoras[0],
-                  { ...selectedLoras[1], lowWeight: parseFloat(e.target.value) || 0 }
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[1].lora}
-              />
-            </div>
+            ))}
           </div>
 
           {/* Face Swap */}
@@ -734,13 +678,14 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
             </FormHelperText>
           </div>
 
-          <div className="modal-actions">
-            <Button type="submit" variant="contained" disabled={uploading}>
-              {uploading ? <CircularProgress size={20} color="inherit" /> : 'Create Job'}
-            </Button>
-          </div>
-        </form>
-      </div>
+        </div>
+
+        <div className="modal-footer">
+          <Button type="submit" variant="contained" disabled={uploading}>
+            {uploading ? <CircularProgress size={20} color="inherit" /> : 'Create Job'}
+          </Button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/react-app/src/components/SubmitPromptModal.jsx
+++ b/react-app/src/components/SubmitPromptModal.jsx
@@ -34,8 +34,9 @@ export default function SubmitPromptModal({
   onSuccess
 }) {
   const [prompt, setPrompt] = useState(defaultPrompt);
-  // Two LoRA slots, each with lora object and weights
+  // Three LoRA slots, each with lora object and weights
   const [selectedLoras, setSelectedLoras] = useState([
+    { lora: null, highWeight: 1, lowWeight: 1 },
     { lora: null, highWeight: 1, lowWeight: 1 },
     { lora: null, highWeight: 1, lowWeight: 1 }
   ]);
@@ -67,10 +68,11 @@ export default function SubmitPromptModal({
     if (defaultLoras && defaultLoras.length > 0) {
       const newSelectedLoras = [
         { lora: null, highWeight: 1, lowWeight: 1 },
+        { lora: null, highWeight: 1, lowWeight: 1 },
         { lora: null, highWeight: 1, lowWeight: 1 }
       ];
 
-      defaultLoras.slice(0, 2).forEach((defaultLora, idx) => {
+      defaultLoras.slice(0, 3).forEach((defaultLora, idx) => {
         if (defaultLora && (defaultLora.high_file || defaultLora.low_file)) {
           const matchingLora = loras.find(l =>
             l.high_file === defaultLora.high_file || l.low_file === defaultLora.high_file ||
@@ -86,7 +88,7 @@ export default function SubmitPromptModal({
         }
       });
 
-      if (newSelectedLoras[0].lora || newSelectedLoras[1].lora) {
+      if (newSelectedLoras[0].lora || newSelectedLoras[1].lora || newSelectedLoras[2].lora) {
         setSelectedLoras(newSelectedLoras);
       }
     }
@@ -177,11 +179,14 @@ export default function SubmitPromptModal({
 
   return (
     <div className="modal-overlay">
-      <div className="modal-content">
-        <button type="button" className="modal-close" onClick={onClose}>×</button>
-        <h2>Submit Prompt for Segment {segmentIndex}</h2>
+      <form className="modal-content" onSubmit={handleSubmit}>
+        <div className="modal-header">
+          <h2>Submit Prompt for Segment {segmentIndex}</h2>
+          <button type="button" className="modal-close" onClick={onClose}>×</button>
+        </div>
 
-        {/* Start Image Selection (only for segments > 0) */}
+        <div className="modal-body">
+          {/* Start Image Selection (only for segments > 0) */}
         {segmentIndex > 0 && defaultStartImageUrl && (
           <div style={{ marginBottom: '16px', padding: '12px', background: '#f5f5f5', borderRadius: '8px', border: '1px solid #e0e0e0' }}>
             <div style={{ fontSize: '13px', fontWeight: 500, marginBottom: '8px', color: '#666' }}>Start Image</div>
@@ -235,22 +240,14 @@ export default function SubmitPromptModal({
           </div>
         )}
 
-        {defaultPrompt && (
-          <div style={{ marginBottom: '16px', padding: '12px', background: '#e3f2fd', borderRadius: '4px', border: '1px solid #90caf9' }}>
-            <span style={{ fontSize: '13px', color: '#1976d2' }}>
-              Values pre-filled from previous segment. Modify as needed.
-            </span>
-          </div>
-        )}
 
-        <form onSubmit={handleSubmit}>
           <div className="form-group">
             <TextField
               label="Prompt"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               multiline
-              rows={4}
+              rows={2}
               placeholder="Describe what happens in this segment..."
               autoFocus
               fullWidth
@@ -274,135 +271,73 @@ export default function SubmitPromptModal({
             </button>
           </div>
 
-          {/* LoRA 1 */}
-          <div className="form-group">
-            <label style={{ marginBottom: '8px', display: 'block' }}>LoRA 1 (optional)</label>
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
-              <div style={{ flex: 1 }}>
+          {/* LoRAs - 3 columns */}
+          <div className="lora-grid">
+            {[0, 1, 2].map((idx) => (
+              <div key={idx} className="lora-slot">
+                <div className="lora-slot-header">LoRA {idx + 1} (optional)</div>
                 <LoraAutocomplete
                   label=""
-                  value={selectedLoras[0].lora}
+                  value={selectedLoras[idx].lora}
                   onChange={(lora) => {
-                    setSelectedLoras(prev => [
-                      {
-                        lora,
-                        highWeight: lora?.default_high_weight ?? 1,
-                        lowWeight: lora?.default_low_weight ?? 1
-                      },
-                      prev[1]
-                    ]);
-                    populatePromptFromLora(lora);
-                  }}
-                  loras={loras}
-                />
-                <button
-                  type="button"
-                  onClick={() => appendLoraPrompt(selectedLoras[0].lora)}
-                  disabled={!selectedLoras[0].lora || !getLoraPromptText(selectedLoras[0].lora)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: selectedLoras[0].lora && getLoraPromptText(selectedLoras[0].lora) ? '#1976d2' : '#ccc',
-                    cursor: selectedLoras[0].lora && getLoraPromptText(selectedLoras[0].lora) ? 'pointer' : 'default',
-                    fontSize: '12px',
-                    padding: '4px 0',
-                    textDecoration: 'underline'
-                  }}
-                >
-                  + Add prompt
-                </button>
-              </div>
-              <TextField
-                type="number"
-                label="High"
-                size="small"
-                value={selectedLoras[0].highWeight}
-                onChange={(e) => setSelectedLoras(prev => [
-                  { ...prev[0], highWeight: parseFloat(e.target.value) || 0 },
-                  prev[1]
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[0].lora}
-              />
-              <TextField
-                type="number"
-                label="Low"
-                size="small"
-                value={selectedLoras[0].lowWeight}
-                onChange={(e) => setSelectedLoras(prev => [
-                  { ...prev[0], lowWeight: parseFloat(e.target.value) || 0 },
-                  prev[1]
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[0].lora}
-              />
-            </div>
-          </div>
-
-          {/* LoRA 2 */}
-          <div className="form-group">
-            <label style={{ marginBottom: '8px', display: 'block' }}>LoRA 2 (optional)</label>
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
-              <div style={{ flex: 1 }}>
-                <LoraAutocomplete
-                  label=""
-                  value={selectedLoras[1].lora}
-                  onChange={(lora) => setSelectedLoras(prev => [
-                    prev[0],
-                    {
+                    const newLoras = [...selectedLoras];
+                    newLoras[idx] = {
                       lora,
                       highWeight: lora?.default_high_weight ?? 1,
                       lowWeight: lora?.default_low_weight ?? 1
-                    }
-                  ])}
+                    };
+                    setSelectedLoras(newLoras);
+                    if (idx === 0) populatePromptFromLora(lora);
+                  }}
                   loras={loras}
                 />
-                <button
-                  type="button"
-                  onClick={() => appendLoraPrompt(selectedLoras[1].lora)}
-                  disabled={!selectedLoras[1].lora || !getLoraPromptText(selectedLoras[1].lora)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: selectedLoras[1].lora && getLoraPromptText(selectedLoras[1].lora) ? '#1976d2' : '#ccc',
-                    cursor: selectedLoras[1].lora && getLoraPromptText(selectedLoras[1].lora) ? 'pointer' : 'default',
-                    fontSize: '12px',
-                    padding: '4px 0',
-                    textDecoration: 'underline'
-                  }}
-                >
-                  + Add prompt
-                </button>
+                <div className="lora-weights">
+                  <TextField
+                    type="number"
+                    label="High"
+                    size="small"
+                    value={selectedLoras[idx].highWeight}
+                    onChange={(e) => {
+                      const newLoras = [...selectedLoras];
+                      newLoras[idx] = { ...newLoras[idx], highWeight: parseFloat(e.target.value) || 0 };
+                      setSelectedLoras(newLoras);
+                    }}
+                    inputProps={{ min: 0, max: 2, step: 0.1 }}
+                    disabled={!selectedLoras[idx].lora}
+                  />
+                  <TextField
+                    type="number"
+                    label="Low"
+                    size="small"
+                    value={selectedLoras[idx].lowWeight}
+                    onChange={(e) => {
+                      const newLoras = [...selectedLoras];
+                      newLoras[idx] = { ...newLoras[idx], lowWeight: parseFloat(e.target.value) || 0 };
+                      setSelectedLoras(newLoras);
+                    }}
+                    inputProps={{ min: 0, max: 2, step: 0.1 }}
+                    disabled={!selectedLoras[idx].lora}
+                  />
+                </div>
+                {selectedLoras[idx].lora && getLoraPromptText(selectedLoras[idx].lora) && (
+                  <button
+                    type="button"
+                    onClick={() => appendLoraPrompt(selectedLoras[idx].lora)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: '#1976d2',
+                      cursor: 'pointer',
+                      fontSize: '11px',
+                      padding: '4px 0 0 0',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    + Add prompt
+                  </button>
+                )}
               </div>
-              <TextField
-                type="number"
-                label="High"
-                size="small"
-                value={selectedLoras[1].highWeight}
-                onChange={(e) => setSelectedLoras(prev => [
-                  prev[0],
-                  { ...prev[1], highWeight: parseFloat(e.target.value) || 0 }
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[1].lora}
-              />
-              <TextField
-                type="number"
-                label="Low"
-                size="small"
-                value={selectedLoras[1].lowWeight}
-                onChange={(e) => setSelectedLoras(prev => [
-                  prev[0],
-                  { ...prev[1], lowWeight: parseFloat(e.target.value) || 0 }
-                ])}
-                inputProps={{ min: 0, max: 2, step: 0.1 }}
-                sx={{ width: '80px' }}
-                disabled={!selectedLoras[1].lora}
-              />
-            </div>
+            ))}
           </div>
 
           {/* Face Swap */}
@@ -484,17 +419,18 @@ export default function SubmitPromptModal({
             </FormHelperText>
           </div>
 
-          <div className="modal-actions">
-            <Button
-              type="submit"
-              variant="contained"
-              disabled={submitting}
-            >
-              {submitting ? <CircularProgress size={20} color="inherit" /> : 'Submit Prompt'}
-            </Button>
-          </div>
-        </form>
-      </div>
+        </div>
+
+        <div className="modal-footer">
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={submitting}
+          >
+            {submitting ? <CircularProgress size={20} color="inherit" /> : 'Submit Prompt'}
+          </Button>
+        </div>
+      </form>
 
       {/* Image Browser Modal for custom start image selection */}
       {showImageBrowser && (


### PR DESCRIPTION
- Add third LoRA slot (nodes 122/123) to workflow templates
- Update backend routes to support 3 LoRA pairs
- Redesign modals with sticky header (blue) and footer (grey)
- Add 3-column LoRA grid layout
- Reduce prompt field to 2 rows
- Make modal body scrollable between fixed header/footer