### PR TITLE
Fix fade-to-black using libopenh264 instead of libx264

### DIFF
--- a/backend/video_utils.py
+++ b/backend/video_utils.py
@@ -219,9 +219,7 @@ def apply_fade_effects(input_path: str, output_path: str, fade_in: bool = False,
             "-y",
             "-i", input_path,
             "-vf", filter_string,
-            "-c:v", "libx264",
-            "-preset", "fast",
-            "-crf", "18",
+            "-c:v", "libopenh264",
             "-pix_fmt", "yuv420p",
             output_path
         ]


### PR DESCRIPTION
The system's ffmpeg package doesn't include libx264 encoder. Using libopenh264 which is available as the H.264 encoder.

Fixes #87