### PR TITLE
Add Swagger API documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,9 @@ Persistent data is stored in `~/backups/` with symlinks in `backend/`:
 
 ### Ports
 - Frontend: http://localhost:3030
-- Backend: http://localhost:9090
+- Backend API: http://localhost:9090
+- API Documentation (Swagger): http://localhost:9090/docs
+- API Documentation (ReDoc): http://localhost:9090/redoc
 - ComfyUI: Configured in Settings (default: http://localhost:8188)
 
 ## Git Guidelines

--- a/backend/main.py
+++ b/backend/main.py
@@ -168,6 +168,8 @@ async def lifespan(app: FastAPI):
         queue_manager.start()
         print("Queue manager auto-started")
 
+    print("API Documentation available at: http://localhost:9090/docs")
+
     yield
 
     # Shutdown


### PR DESCRIPTION
FastAPI has built-in Swagger support. This commit:
- Documents the API docs URLs in CLAUDE.md
- Adds startup message showing docs URL

API Documentation URLs:
- Swagger UI: http://localhost:9090/docs
- ReDoc: http://localhost:9090/redoc

Fixes #110