### PR TITLE
Add double arrows to push jobs to top/bottom of queue (#128)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -706,6 +706,27 @@ def move_job_down(job_id: int) -> bool:
         return True
 
 
+def move_job_to_top(job_id: int) -> bool:
+    """Move a job to the top of the queue (set priority to MIN - 1).
+
+    Returns True if the job was moved, False if job not found or not pending.
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+
+        # Verify job exists and is pending
+        cursor.execute("SELECT id FROM jobs WHERE id = ? AND status = 'pending'", (job_id,))
+        if not cursor.fetchone():
+            return False
+
+        # Get min priority and set this job to min - 1
+        cursor.execute("SELECT COALESCE(MIN(priority), 0) - 1 FROM jobs WHERE status = 'pending'")
+        new_priority = cursor.fetchone()[0]
+
+        cursor.execute("UPDATE jobs SET priority = ? WHERE id = ?", (new_priority, job_id))
+        return True
+
+
 def move_job_to_bottom(job_id: int) -> bool:
     """Move a job to the bottom of the queue (set priority to MAX + 1).
 
@@ -715,13 +736,13 @@ def move_job_to_bottom(job_id: int) -> bool:
     with get_connection() as conn:
         cursor = conn.cursor()
 
-        # Verify job exists
-        cursor.execute("SELECT id FROM jobs WHERE id = ?", (job_id,))
+        # Verify job exists and is pending
+        cursor.execute("SELECT id FROM jobs WHERE id = ? AND status = 'pending'", (job_id,))
         if not cursor.fetchone():
             return False
 
         # Get max priority and set this job to max + 1
-        cursor.execute("SELECT COALESCE(MAX(priority), 0) + 1 FROM jobs")
+        cursor.execute("SELECT COALESCE(MAX(priority), 0) + 1 FROM jobs WHERE status = 'pending'")
         next_priority = cursor.fetchone()[0]
 
         cursor.execute("UPDATE jobs SET priority = ? WHERE id = ?", (next_priority, job_id))

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -49,6 +49,7 @@ from database import (
     get_all_image_ratings,
     move_job_up,
     move_job_down,
+    move_job_to_top,
     move_job_to_bottom,
     hide_lora_file,
     unhide_lora_file,
@@ -665,6 +666,40 @@ async def move_job_down_endpoint(job_id: int):
         return {"status": "unchanged", "id": job_id, "message": "Job is already at the bottom of the queue"}
 
     return {"status": "moved", "id": job_id, "direction": "down"}
+
+
+@router.post("/jobs/{job_id}/move-to-top")
+async def move_job_to_top_endpoint(job_id: int):
+    """Move a pending job to the top of the queue (highest priority)."""
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job["status"] != "pending":
+        raise HTTPException(status_code=400, detail="Only pending jobs can be reordered")
+
+    moved = move_job_to_top(job_id)
+    if not moved:
+        return {"status": "unchanged", "id": job_id, "message": "Job is already at the top of the queue"}
+
+    return {"status": "moved", "id": job_id, "direction": "top"}
+
+
+@router.post("/jobs/{job_id}/move-to-bottom")
+async def move_job_to_bottom_endpoint(job_id: int):
+    """Move a pending job to the bottom of the queue (lowest priority)."""
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job["status"] != "pending":
+        raise HTTPException(status_code=400, detail="Only pending jobs can be reordered")
+
+    moved = move_job_to_bottom(job_id)
+    if not moved:
+        return {"status": "unchanged", "id": job_id, "message": "Job is already at the bottom of the queue"}
+
+    return {"status": "moved", "id": job_id, "direction": "bottom"}
 
 
 @router.post("/jobs/{job_id}/retry")

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -126,6 +126,18 @@ class APIClient {
     });
   }
 
+  async moveJobToTop(jobId) {
+    return this.request(`/jobs/${jobId}/move-to-top`, {
+      method: 'POST'
+    });
+  }
+
+  async moveJobToBottom(jobId) {
+    return this.request(`/jobs/${jobId}/move-to-bottom`, {
+      method: 'POST'
+    });
+  }
+
   // ============== Settings ==============
 
   async getSettings() {

--- a/react-app/src/pages/Queue.jsx
+++ b/react-app/src/pages/Queue.jsx
@@ -21,6 +21,8 @@ import {
 } from '@mui/material';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
 import API from '../api/client';
 import { useJobs } from '../contexts/JobsContext';
 import { formatDate, showToast, getFaceswapName } from '../utils/helpers';
@@ -174,6 +176,28 @@ export default function Queue() {
     }
   }
 
+  async function handleMoveToTop(jobId, event) {
+    event.stopPropagation();
+    try {
+      await API.moveJobToTop(jobId);
+      await refreshJobs();
+    } catch (error) {
+      console.error('Failed to move job to top:', error);
+      showToast('Failed to move job', 'error');
+    }
+  }
+
+  async function handleMoveToBottom(jobId, event) {
+    event.stopPropagation();
+    try {
+      await API.moveJobToBottom(jobId);
+      await refreshJobs();
+    } catch (error) {
+      console.error('Failed to move job to bottom:', error);
+      showToast('Failed to move job', 'error');
+    }
+  }
+
   if (loading) {
     return (
       <div>
@@ -270,9 +294,19 @@ export default function Queue() {
                             <div style={{ display: 'flex', flexDirection: 'column' }}>
                               <IconButton
                                 size="small"
+                                onClick={(e) => handleMoveToTop(job.id, e)}
+                                disabled={isFirstPending}
+                                sx={{ padding: '1px' }}
+                                title="Move to top"
+                              >
+                                <KeyboardDoubleArrowUpIcon fontSize="small" />
+                              </IconButton>
+                              <IconButton
+                                size="small"
                                 onClick={(e) => handleMoveUp(job.id, e)}
                                 disabled={isFirstPending}
-                                sx={{ padding: '2px' }}
+                                sx={{ padding: '1px' }}
+                                title="Move up"
                               >
                                 <KeyboardArrowUpIcon fontSize="small" />
                               </IconButton>
@@ -280,9 +314,19 @@ export default function Queue() {
                                 size="small"
                                 onClick={(e) => handleMoveDown(job.id, e)}
                                 disabled={isLastPending}
-                                sx={{ padding: '2px' }}
+                                sx={{ padding: '1px' }}
+                                title="Move down"
                               >
                                 <KeyboardArrowDownIcon fontSize="small" />
+                              </IconButton>
+                              <IconButton
+                                size="small"
+                                onClick={(e) => handleMoveToBottom(job.id, e)}
+                                disabled={isLastPending}
+                                sx={{ padding: '1px' }}
+                                title="Move to bottom"
+                              >
+                                <KeyboardDoubleArrowDownIcon fontSize="small" />
                               </IconButton>
                             </div>
                           </div>


### PR DESCRIPTION
Backend:
- Add move_job_to_top() function in database.py
- Update move_job_to_bottom() to only work on pending jobs
- Add /jobs/{id}/move-to-top and /jobs/{id}/move-to-bottom API endpoints

Frontend:
- Add moveJobToTop() and moveJobToBottom() API client methods
- Add double arrow icons (KeyboardDoubleArrowUp/Down) to Queue page
- Four arrow buttons per pending job: to-top, up, down, to-bottom
- Added title tooltips for clarity

Closes #128