### PR TITLE
Add video upscaling via Real-ESRGAN on 3090 server (#134)

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2215,3 +2215,146 @@ async def remove_image_tag(image_path: str, tag_name: str):
     if removed:
         return {"image_path": image_path, "tag_name": tag_name, "message": "Tag removed from image"}
     raise HTTPException(status_code=404, detail="Tag association not found")
+
+
+# ============== Video Upscaling Routes ==============
+
+from upscale import upscale_video, get_available_models, MODELS as UPSCALE_MODELS
+
+
+class UpscaleRequest(BaseModel):
+    """Request body for video upscaling."""
+    video_path: str
+    scale: int = 2
+    model: str = "realesr-animevideov3"
+    output_path: Optional[str] = None
+
+
+@router.get("/upscale/models")
+async def get_upscale_models():
+    """Get available upscaling models and their supported scales."""
+    return {"models": get_available_models()}
+
+
+@router.post("/upscale")
+async def upscale_video_endpoint(request: UpscaleRequest):
+    """Upscale a video using Real-ESRGAN on the 3090 server.
+
+    Args:
+        video_path: Path to the video file to upscale
+        scale: Upscale factor (2, 3, or 4 depending on model)
+        model: Model name (realesrgan-x4plus, realesr-animevideov3, etc.)
+        output_path: Optional custom output path
+
+    Returns:
+        Status and path to upscaled video
+    """
+    # Validate video path exists
+    if not os.path.exists(request.video_path):
+        raise HTTPException(status_code=404, detail=f"Video not found: {request.video_path}")
+
+    # Validate model
+    if request.model not in UPSCALE_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown model: {request.model}. Available: {list(UPSCALE_MODELS.keys())}"
+        )
+
+    # Validate scale for model
+    model_info = UPSCALE_MODELS[request.model]
+    if request.scale not in model_info["scales"]:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Scale {request.scale} not supported for {request.model}. Available: {model_info['scales']}"
+        )
+
+    # Run upscaling
+    result = upscale_video(
+        input_path=request.video_path,
+        output_path=request.output_path,
+        scale=request.scale,
+        model=request.model
+    )
+
+    if result["status"] == "error":
+        raise HTTPException(status_code=500, detail=result.get("error", "Upscaling failed"))
+
+    return result
+
+
+@router.post("/jobs/{job_id}/upscale")
+async def upscale_job_video(job_id: int, scale: int = 2, model: str = "realesr-animevideov3"):
+    """Upscale a job's final video.
+
+    The job must be completed and have a final video.
+    """
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job["status"] != "completed":
+        raise HTTPException(status_code=400, detail="Job is not completed")
+
+    # Find the final video
+    from video_utils import get_final_video_path
+    video_path = get_final_video_path(job_id, job.get("name", f"job_{job_id}"))
+
+    if not video_path or not os.path.exists(video_path):
+        raise HTTPException(status_code=404, detail="Final video not found for this job")
+
+    # Generate output path
+    video_stem = Path(video_path).stem
+    video_dir = Path(video_path).parent
+    output_path = str(video_dir / f"{video_stem}_upscaled_{scale}x.mp4")
+
+    # Run upscaling
+    result = upscale_video(
+        input_path=video_path,
+        output_path=output_path,
+        scale=scale,
+        model=model
+    )
+
+    if result["status"] == "error":
+        raise HTTPException(status_code=500, detail=result.get("error", "Upscaling failed"))
+
+    return result
+
+
+@router.get("/jobs/{job_id}/segments/{segment_index}/upscale")
+async def upscale_segment_video(job_id: int, segment_index: int, scale: int = 2, model: str = "realesr-animevideov3"):
+    """Upscale a specific segment's video."""
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    segment = get_segment(job_id, segment_index)
+    if not segment:
+        raise HTTPException(status_code=404, detail="Segment not found")
+
+    if segment["status"] != "completed":
+        raise HTTPException(status_code=400, detail="Segment is not completed")
+
+    # Find the segment video
+    video_path = get_segment_video_path(job_id, segment_index, job.get("name", f"job_{job_id}"))
+
+    if not video_path or not os.path.exists(video_path):
+        raise HTTPException(status_code=404, detail="Segment video not found")
+
+    # Generate output path
+    video_stem = Path(video_path).stem
+    video_dir = Path(video_path).parent
+    output_path = str(video_dir / f"{video_stem}_upscaled_{scale}x.mp4")
+
+    # Run upscaling
+    result = upscale_video(
+        input_path=video_path,
+        output_path=output_path,
+        scale=scale,
+        model=model
+    )
+
+    if result["status"] == "error":
+        raise HTTPException(status_code=500, detail=result.get("error", "Upscaling failed"))
+
+    return result

--- a/backend/upscale.py
+++ b/backend/upscale.py
@@ -1,0 +1,221 @@
+"""Video upscaling using Real-ESRGAN on remote 3090 server."""
+
+import os
+import subprocess
+import tempfile
+import shutil
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Remote server configuration
+REMOTE_HOST = "david@3090.zero"
+REMOTE_TOOLS_DIR = "/home/david/tools"
+REALESRGAN_BIN = f"{REMOTE_TOOLS_DIR}/realesrgan-ncnn-vulkan"
+REMOTE_WORK_DIR = "/tmp/upscale_work"
+
+# Available models
+MODELS = {
+    "realesrgan-x4plus": {"scales": [2, 4], "default_scale": 4},
+    "realesrgan-x4plus-anime": {"scales": [2, 4], "default_scale": 4},
+    "realesr-animevideov3": {"scales": [2, 3, 4], "default_scale": 2},
+}
+
+DEFAULT_MODEL = "realesr-animevideov3"
+
+
+def run_ssh_command(cmd: str, timeout: int = 600) -> tuple[int, str, str]:
+    """Run a command on the remote server via SSH."""
+    full_cmd = f'ssh {REMOTE_HOST} "{cmd}"'
+    logger.info(f"SSH: {cmd}")
+    try:
+        result = subprocess.run(
+            full_cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return -1, "", "Command timed out"
+
+
+def scp_to_remote(local_path: str, remote_path: str) -> bool:
+    """Copy a file to the remote server."""
+    cmd = f"scp {local_path} {REMOTE_HOST}:{remote_path}"
+    logger.info(f"SCP upload: {local_path} -> {remote_path}")
+    result = subprocess.run(cmd, shell=True, capture_output=True)
+    return result.returncode == 0
+
+
+def scp_from_remote(remote_path: str, local_path: str) -> bool:
+    """Copy a file from the remote server."""
+    cmd = f"scp {REMOTE_HOST}:{remote_path} {local_path}"
+    logger.info(f"SCP download: {remote_path} -> {local_path}")
+    result = subprocess.run(cmd, shell=True, capture_output=True)
+    return result.returncode == 0
+
+
+def upscale_video(
+    input_path: str,
+    output_path: str = None,
+    scale: int = 2,
+    model: str = DEFAULT_MODEL,
+    progress_callback=None
+) -> dict:
+    """
+    Upscale a video using Real-ESRGAN on the remote 3090 server.
+
+    Args:
+        input_path: Path to input video file (local)
+        output_path: Path for output video (local), auto-generated if None
+        scale: Upscale factor (2, 3, or 4 depending on model)
+        model: Model name (realesrgan-x4plus, realesr-animevideov3, etc.)
+        progress_callback: Optional callback(stage, percent, message)
+
+    Returns:
+        dict with status, output_path, and any error message
+    """
+
+    def report_progress(stage: str, percent: int, message: str = ""):
+        logger.info(f"[{stage}] {percent}% - {message}")
+        if progress_callback:
+            progress_callback(stage, percent, message)
+
+    # Validate inputs
+    if not os.path.exists(input_path):
+        return {"status": "error", "error": f"Input file not found: {input_path}"}
+
+    if model not in MODELS:
+        return {"status": "error", "error": f"Unknown model: {model}. Available: {list(MODELS.keys())}"}
+
+    model_info = MODELS[model]
+    if scale not in model_info["scales"]:
+        return {"status": "error", "error": f"Scale {scale} not supported for {model}. Available: {model_info['scales']}"}
+
+    # Generate output path if not provided
+    if output_path is None:
+        input_stem = Path(input_path).stem
+        input_dir = Path(input_path).parent
+        output_path = str(input_dir / f"{input_stem}_upscaled_{scale}x.mp4")
+
+    # Create unique work directory on remote
+    import uuid
+    work_id = str(uuid.uuid4())[:8]
+    remote_work = f"{REMOTE_WORK_DIR}/{work_id}"
+
+    try:
+        report_progress("setup", 0, "Creating remote work directory")
+
+        # Create work directory on remote
+        ret, _, err = run_ssh_command(f"mkdir -p {remote_work}/frames_in {remote_work}/frames_out")
+        if ret != 0:
+            return {"status": "error", "error": f"Failed to create work directory: {err}"}
+
+        # Upload video to remote
+        report_progress("upload", 5, "Uploading video to server")
+        remote_input = f"{remote_work}/input{Path(input_path).suffix}"
+        if not scp_to_remote(input_path, remote_input):
+            return {"status": "error", "error": "Failed to upload video"}
+
+        # Extract frames using ffmpeg on remote
+        report_progress("extract", 15, "Extracting frames")
+        ret, stdout, stderr = run_ssh_command(
+            f"ffmpeg -i {remote_input} -qscale:v 2 {remote_work}/frames_in/frame_%06d.png -y 2>&1",
+            timeout=300
+        )
+        if ret != 0:
+            return {"status": "error", "error": f"Failed to extract frames: {stderr}"}
+
+        # Count frames
+        ret, stdout, _ = run_ssh_command(f"ls {remote_work}/frames_in | wc -l")
+        frame_count = int(stdout.strip()) if ret == 0 else 0
+        logger.info(f"Extracted {frame_count} frames")
+
+        # Get video framerate
+        ret, stdout, _ = run_ssh_command(
+            f"ffprobe -v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate {remote_input}"
+        )
+        fps = "30" # default
+        if ret == 0 and stdout.strip():
+            fps_parts = stdout.strip().split('/')
+            if len(fps_parts) == 2:
+                fps = str(int(fps_parts[0]) // int(fps_parts[1]))
+            else:
+                fps = fps_parts[0]
+        logger.info(f"Video FPS: {fps}")
+
+        # Run Real-ESRGAN upscaling
+        report_progress("upscale", 30, f"Upscaling {frame_count} frames with {model} ({scale}x)")
+        ret, stdout, stderr = run_ssh_command(
+            f"cd {REMOTE_TOOLS_DIR} && ./realesrgan-ncnn-vulkan "
+            f"-i {remote_work}/frames_in "
+            f"-o {remote_work}/frames_out "
+            f"-n {model} -s {scale} -f png 2>&1",
+            timeout=1800  # 30 min timeout for upscaling
+        )
+        if ret != 0:
+            return {"status": "error", "error": f"Upscaling failed: {stderr or stdout}"}
+
+        # Check upscaled frames exist
+        ret, stdout, _ = run_ssh_command(f"ls {remote_work}/frames_out | wc -l")
+        upscaled_count = int(stdout.strip()) if ret == 0 else 0
+        if upscaled_count == 0:
+            return {"status": "error", "error": "No upscaled frames produced"}
+        logger.info(f"Upscaled {upscaled_count} frames")
+
+        # Reassemble video with ffmpeg
+        report_progress("reassemble", 80, "Reassembling video")
+        remote_output = f"{remote_work}/output.mp4"
+
+        # Check if input has audio
+        ret, stdout, _ = run_ssh_command(
+            f"ffprobe -v 0 -select_streams a -show_entries stream=codec_type -of csv=p=0 {remote_input}"
+        )
+        has_audio = ret == 0 and "audio" in stdout
+
+        if has_audio:
+            # Reassemble with audio from original
+            ret, stdout, stderr = run_ssh_command(
+                f"ffmpeg -framerate {fps} -i {remote_work}/frames_out/frame_%06d.png "
+                f"-i {remote_input} -map 0:v -map 1:a -c:v libx264 -preset medium "
+                f"-crf 18 -pix_fmt yuv420p -c:a aac -shortest {remote_output} -y 2>&1",
+                timeout=300
+            )
+        else:
+            # No audio
+            ret, stdout, stderr = run_ssh_command(
+                f"ffmpeg -framerate {fps} -i {remote_work}/frames_out/frame_%06d.png "
+                f"-c:v libx264 -preset medium -crf 18 -pix_fmt yuv420p {remote_output} -y 2>&1",
+                timeout=300
+            )
+
+        if ret != 0:
+            return {"status": "error", "error": f"Failed to reassemble video: {stderr or stdout}"}
+
+        # Download result
+        report_progress("download", 90, "Downloading upscaled video")
+        if not scp_from_remote(remote_output, output_path):
+            return {"status": "error", "error": "Failed to download upscaled video"}
+
+        report_progress("complete", 100, "Upscaling complete")
+
+        return {
+            "status": "success",
+            "output_path": output_path,
+            "scale": scale,
+            "model": model,
+            "frames_processed": upscaled_count
+        }
+
+    finally:
+        # Cleanup remote work directory
+        logger.info(f"Cleaning up remote work directory: {remote_work}")
+        run_ssh_command(f"rm -rf {remote_work}", timeout=60)
+
+
+def get_available_models() -> dict:
+    """Return available upscaling models and their supported scales."""
+    return MODELS

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -481,6 +481,18 @@ class APIClient {
       method: 'POST'
     });
   }
+
+  // ============== Video Upscaling ==============
+
+  async getUpscaleModels() {
+    return this.request('/upscale/models');
+  }
+
+  async upscaleJobVideo(jobId, scale = 2, model = 'realesr-animevideov3') {
+    return this.request(`/jobs/${jobId}/upscale?scale=${scale}&model=${encodeURIComponent(model)}`, {
+      method: 'POST'
+    });
+  }
 }
 
 export default new APIClient();

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -71,6 +71,7 @@ export default function JobDetail() {
   const [progress, setProgress] = useState(null);
   const [elapsedTime, setElapsedTime] = useState(null);
   const [finalizing, setFinalizing] = useState(false);
+  const [upscaling, setUpscaling] = useState(false);
   const autoFinalizeTriggeredRef = useRef(false);
 
   // Memoize expensive segment calculations - must be before early returns
@@ -362,6 +363,22 @@ export default function JobDetail() {
     }
   }
 
+  async function handleUpscaleVideo() {
+    setUpscaling(true);
+    showToast('Starting video upscale... This may take a few minutes.', 'info');
+
+    try {
+      const result = await API.upscaleJobVideo(id, 2, 'realesr-animevideov3');
+      showToast(`Video upscaled successfully (${result.scale}x)`, 'success');
+      await loadJobDetail();
+    } catch (error) {
+      console.error('Failed to upscale video:', error);
+      showToast(error.message || 'Failed to upscale video', 'error');
+    } finally {
+      setUpscaling(false);
+    }
+  }
+
   async function handleDeleteJob() {
     if (!confirm('Are you sure you want to delete this job?')) return;
 
@@ -538,13 +555,28 @@ export default function JobDetail() {
             >
               Your browser does not support video playback.
             </video>
-            <div style={{ marginTop: '12px' }}>
+            <div style={{ marginTop: '12px', display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
               <Button
                 variant="contained"
                 href={API.getJobVideo(id)}
                 download={`${job.name}.webm`}
               >
                 Download Video
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={handleUpscaleVideo}
+                disabled={upscaling}
+                sx={{ borderColor: '#7b1fa2', color: '#7b1fa2', '&:hover': { borderColor: '#6a1b9a', bgcolor: 'rgba(123, 31, 162, 0.04)' } }}
+              >
+                {upscaling ? (
+                  <>
+                    <CircularProgress size={20} color="inherit" sx={{ mr: 1 }} />
+                    Upscaling...
+                  </>
+                ) : (
+                  'Upscale 2x'
+                )}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
- Add backend/upscale.py with SSH-based upscaling pipeline
- Add API endpoints: GET /upscale/models, POST /jobs/{id}/upscale
- Add upscaleJobVideo() method to API client
- Add Upscale 2x button on JobDetail page for completed jobs

Uses realesrgan-ncnn-vulkan installed at ~/tools on 3090 server. Pipeline: upload video → extract frames → upscale → reassemble → download.