### PR TITLE
Fix CreateJobModal using hardcoded dimensions instead of settings

### DIFF
--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -5,7 +5,7 @@ import API from '../api/client';
 import { showToast } from '../utils/helpers';
 import './CreateJobModal.css';
 
-export default function ImagePreviewModal({ image, images, currentIndex, onClose, onCreateJob, onDelete, onNavigate }) {
+export default function ImagePreviewModal({ image, images, currentIndex, onClose, onCreateJob, onDelete, onNavigate, defaultWidth = 1280, defaultHeight = 720 }) {
   const [deleting, setDeleting] = useState(false);
   const [creatingJob, setCreatingJob] = useState(false);
   const [rating, setRating] = useState(image.rating || null);
@@ -155,17 +155,18 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
       const data = await API.selectImageFromRepo(image.path);
       showToast('Image uploaded successfully!', 'success');
 
-      // Get dimensions from the already-displayed image element
-      let dimensions = { width: 768, height: 512 }; // Default to landscape
+      // Get dimensions from the already-displayed image element, using settings defaults
+      let dimensions = { width: defaultWidth, height: defaultHeight }; // Default to landscape from settings
       if (imageRef.current) {
         const naturalW = imageRef.current.naturalWidth;
         const naturalH = imageRef.current.naturalHeight;
         console.log('[ImagePreviewModal] Image natural dimensions:', naturalW, 'x', naturalH);
         if (naturalW && naturalH) {
           const isLandscape = naturalW > naturalH;
+          // Use settings defaults, swapping for portrait orientation
           dimensions = isLandscape
-            ? { width: 768, height: 512 }
-            : { width: 512, height: 768 };
+            ? { width: defaultWidth, height: defaultHeight }
+            : { width: defaultHeight, height: defaultWidth };
           console.log('[ImagePreviewModal] Setting dimensions:', dimensions, 'isLandscape:', isLandscape);
         } else {
           console.log('[ImagePreviewModal] naturalWidth/Height not available, using defaults');

--- a/react-app/src/pages/ImageRepo.jsx
+++ b/react-app/src/pages/ImageRepo.jsx
@@ -43,6 +43,8 @@ export default function ImageRepo() {
   const [folderPage, setFolderPage] = useState(1);
   const [imagePage, setImagePage] = useState(1);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [defaultWidth, setDefaultWidth] = useState(1280);
+  const [defaultHeight, setDefaultHeight] = useState(720);
 
   // Load tags once
   useEffect(() => {
@@ -309,18 +311,20 @@ export default function ImageRepo() {
     }
   }
 
-  // Load slideshow delay setting
+  // Load settings (slideshow delay, default dimensions)
   useEffect(() => {
-    async function loadSlideshowDelay() {
+    async function loadSettings() {
       try {
         const data = await API.getSettings();
         const settings = data.settings || data;
         setSlideshowDelay(parseInt(settings.slideshow_delay) || 5);
+        setDefaultWidth(parseInt(settings.default_width) || 1280);
+        setDefaultHeight(parseInt(settings.default_height) || 720);
       } catch (err) {
-        console.error('Failed to load slideshow delay:', err);
+        console.error('Failed to load settings:', err);
       }
     }
-    loadSlideshowDelay();
+    loadSettings();
   }, []);
 
   // Slideshow functions
@@ -826,6 +830,8 @@ export default function ImageRepo() {
           onCreateJob={handleCreateJobFromPreview}
           onDelete={handleDeleteImage}
           onNavigate={handleNavigateImage}
+          defaultWidth={defaultWidth}
+          defaultHeight={defaultHeight}
         />
       )}
 


### PR DESCRIPTION
The ImagePreviewModal was using hardcoded 768x512 / 512x768 dimensions when creating a job from the image repository, ignoring the default width/height values configured in settings.

Now ImageRepo loads default_width and default_height from settings and passes them to ImagePreviewModal, which uses them to set the correct dimensions based on image orientation.