### PR TITLE
Add bulk delete feature for Image Repository

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2162,6 +2162,68 @@ async def delete_image_from_repo(image_path: str = Form(...)):
         raise HTTPException(status_code=500, detail=f"Failed to delete image: {str(e)}")
 
 
+@router.post("/image-repo/delete-bulk")
+async def delete_images_bulk(image_paths: List[str] = Form(...)):
+    """Delete multiple images from the repository.
+
+    Permanently removes multiple image files from the local filesystem.
+    Returns results for each image (success or failure).
+    """
+    repo_root = get_setting("image_repo_path", "")
+
+    if not repo_root:
+        raise HTTPException(status_code=400, detail="Image repository path not configured")
+
+    repo_root_path = Path(repo_root)
+    results = []
+    deleted_count = 0
+    failed_count = 0
+
+    for image_path in image_paths:
+        try:
+            # Build full path with security check
+            full_path = repo_root_path / image_path
+            full_path = full_path.resolve()
+
+            # Security: Ensure path is within repo root
+            if not str(full_path).startswith(str(repo_root_path.resolve())):
+                results.append({"path": image_path, "success": False, "error": "Access denied: Path is outside repository"})
+                failed_count += 1
+                continue
+
+            if not full_path.exists():
+                results.append({"path": image_path, "success": False, "error": "Image not found"})
+                failed_count += 1
+                continue
+
+            if not full_path.is_file():
+                results.append({"path": image_path, "success": False, "error": "Path is not a file"})
+                failed_count += 1
+                continue
+
+            # Check file extension for safety
+            if full_path.suffix.lower() not in ['.jpg', '.jpeg', '.png']:
+                results.append({"path": image_path, "success": False, "error": "Only JPG and PNG images can be deleted"})
+                failed_count += 1
+                continue
+
+            # Delete the file
+            full_path.unlink()
+            results.append({"path": image_path, "success": True})
+            deleted_count += 1
+
+        except Exception as e:
+            results.append({"path": image_path, "success": False, "error": str(e)})
+            failed_count += 1
+
+    return {
+        "success": failed_count == 0,
+        "deleted_count": deleted_count,
+        "failed_count": failed_count,
+        "results": results
+    }
+
+
 @router.get("/image-repo/rating")
 async def get_image_rating_endpoint(image_path: str):
     """Get the rating for a specific image."""

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -376,6 +376,16 @@ class APIClient {
     });
   }
 
+  async deleteRepoImagesBulk(imagePaths) {
+    const formData = new FormData();
+    imagePaths.forEach(path => formData.append('image_paths', path));
+
+    return this.request('/image-repo/delete-bulk', {
+      method: 'POST',
+      body: formData
+    });
+  }
+
   async getImageRating(imagePath) {
     return this.request(`/image-repo/rating?image_path=${encodeURIComponent(imagePath)}`);
   }

--- a/react-app/src/pages/ImageRepo.css
+++ b/react-app/src/pages/ImageRepo.css
@@ -73,6 +73,7 @@
   border-radius: 4px;
   background: #f5f5f5;
   margin-bottom: 8px;
+  position: relative;
 }
 
 .repo-item-preview img {

--- a/react-app/src/pages/ImageRepo.jsx
+++ b/react-app/src/pages/ImageRepo.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { FormControl, InputLabel, Select, MenuItem, Pagination, Box, CircularProgress, Button } from '@mui/material';
+import { FormControl, InputLabel, Select, MenuItem, Pagination, Box, CircularProgress, Button, Checkbox } from '@mui/material';
 import LazyImage from '../components/LazyImage';
 
 const FOLDERS_PER_PAGE = 24;
@@ -45,6 +45,8 @@ export default function ImageRepo() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [defaultWidth, setDefaultWidth] = useState(1280);
   const [defaultHeight, setDefaultHeight] = useState(720);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedImages, setSelectedImages] = useState(new Set());
 
   // Load tags once
   useEffect(() => {
@@ -308,6 +310,57 @@ export default function ImageRepo() {
     if (newIndex >= 0 && newIndex < images.length) {
       setSelectedImage(images[newIndex]);
       setSelectedImageIndex(newIndex);
+    }
+  }
+
+  // Selection mode functions
+  function toggleSelectMode() {
+    if (selectMode) {
+      // Exiting select mode - clear selection
+      setSelectedImages(new Set());
+    }
+    setSelectMode(!selectMode);
+  }
+
+  function toggleImageSelection(imagePath) {
+    setSelectedImages(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(imagePath)) {
+        newSet.delete(imagePath);
+      } else {
+        newSet.add(imagePath);
+      }
+      return newSet;
+    });
+  }
+
+  async function handleBulkDelete() {
+    if (selectedImages.size === 0) return;
+
+    const confirmed = window.confirm(`Delete ${selectedImages.size} image${selectedImages.size > 1 ? 's' : ''}? This cannot be undone.`);
+    if (!confirmed) return;
+
+    try {
+      const result = await API.deleteRepoImagesBulk(Array.from(selectedImages));
+
+      if (result.deleted_count > 0) {
+        showToast(`Deleted ${result.deleted_count} image${result.deleted_count > 1 ? 's' : ''}`, 'success');
+        // Remove deleted images from local state
+        const deletedPaths = new Set(result.results.filter(r => r.success).map(r => r.path));
+        setImages(images.filter(img => !deletedPaths.has(img.path)));
+        setAllImages(allImages.filter(img => !deletedPaths.has(img.path)));
+      }
+
+      if (result.failed_count > 0) {
+        showToast(`Failed to delete ${result.failed_count} image${result.failed_count > 1 ? 's' : ''}`, 'error');
+      }
+
+      // Clear selection and exit select mode
+      setSelectedImages(new Set());
+      setSelectMode(false);
+    } catch (error) {
+      console.error('Bulk delete failed:', error);
+      showToast('Failed to delete images', 'error');
     }
   }
 
@@ -580,6 +633,26 @@ export default function ImageRepo() {
             >
               {loadingSlideshow ? <CircularProgress size={16} color="inherit" /> : 'Slideshow'}
             </Button>
+            <div style={{ borderLeft: '1px solid #ddd', height: '24px', margin: '0 4px' }} />
+            <Button
+              variant={selectMode ? "contained" : "outlined"}
+              size="small"
+              onClick={toggleSelectMode}
+              disabled={images.length === 0}
+              color={selectMode ? "primary" : "inherit"}
+            >
+              {selectMode ? 'Cancel' : 'Select'}
+            </Button>
+            {selectMode && selectedImages.size > 0 && (
+              <Button
+                variant="contained"
+                size="small"
+                color="error"
+                onClick={handleBulkDelete}
+              >
+                Delete ({selectedImages.size})
+              </Button>
+            )}
           </div>
         </div>
 
@@ -723,11 +796,13 @@ export default function ImageRepo() {
               {paginatedImages.map((image, index) => {
                 // Calculate actual index in full images array for preview navigation
                 const actualIndex = (imagePage - 1) * IMAGES_PER_PAGE + index;
+                const isSelected = selectedImages.has(image.path);
                 return (
                   <div
                     key={image.path}
-                    className="repo-item image"
-                    onClick={() => openImagePreview(image, actualIndex)}
+                    className={`repo-item image ${isSelected ? 'selected' : ''}`}
+                    onClick={() => selectMode ? toggleImageSelection(image.path) : openImagePreview(image, actualIndex)}
+                    style={isSelected ? { outline: '3px solid #1976d2', outlineOffset: '-3px' } : {}}
                   >
                     <div className="repo-item-preview">
                       <LazyImage
@@ -737,6 +812,23 @@ export default function ImageRepo() {
                           e.target.src = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22200%22 height=%22200%22%3E%3Crect fill=%22%23ddd%22 width=%22200%22 height=%22200%22/%3E%3Ctext x=%2250%25%22 y=%2250%25%22 dominant-baseline=%22middle%22 text-anchor=%22middle%22 fill=%22%23999%22%3E🖼️%3C/text%3E%3C/svg%3E';
                         }}
                       />
+                      {selectMode && (
+                        <Checkbox
+                          checked={isSelected}
+                          onClick={(e) => e.stopPropagation()}
+                          onChange={() => toggleImageSelection(image.path)}
+                          sx={{
+                            position: 'absolute',
+                            top: 4,
+                            left: 4,
+                            padding: '2px',
+                            backgroundColor: 'rgba(255,255,255,0.8)',
+                            borderRadius: '4px',
+                            '&:hover': { backgroundColor: 'rgba(255,255,255,0.95)' }
+                          }}
+                          size="small"
+                        />
+                      )}
                     </div>
                     <div className="repo-item-name">
                       {image.name}
@@ -766,12 +858,23 @@ export default function ImageRepo() {
 
               {paginatedImages.map((image, index) => {
                 const actualIndex = (imagePage - 1) * IMAGES_PER_PAGE + index;
+                const isSelected = selectedImages.has(image.path);
                 return (
                   <div
                     key={image.path}
-                    className="repo-list-item image"
-                    onClick={() => openImagePreview(image, actualIndex)}
+                    className={`repo-list-item image ${isSelected ? 'selected' : ''}`}
+                    onClick={() => selectMode ? toggleImageSelection(image.path) : openImagePreview(image, actualIndex)}
+                    style={isSelected ? { backgroundColor: '#e3f2fd' } : {}}
                   >
+                    {selectMode && (
+                      <Checkbox
+                        checked={isSelected}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => toggleImageSelection(image.path)}
+                        size="small"
+                        sx={{ padding: '4px', marginRight: '4px' }}
+                      />
+                    )}
                     <span className="repo-list-icon">🖼️</span>
                     <span className="repo-list-name">
                       {image.name}


### PR DESCRIPTION
- Add Select mode toggle button in toolbar
- Show checkboxes on image thumbnails when in select mode
- Clicking images toggles selection (blocks preview in select mode)
- Delete (X) button appears when images are selected
- Browser confirm dialog before deletion
- New POST /api/image-repo/delete-bulk endpoint for batch deletion
- Works in both grid and list view modes