### PR TITLE
Fix upscaled videos tracking - use database instead of filename matching

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -469,6 +469,26 @@ def init_db():
             CREATE INDEX IF NOT EXISTS idx_image_tags_v2_tag ON image_tags_v2(tag_name)
         """)
 
+        # Upscaled videos table - tracks upscaled videos associated with jobs
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS upscaled_videos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id INTEGER NOT NULL,
+                filename TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                scale INTEGER NOT NULL,
+                model TEXT NOT NULL,
+                file_size INTEGER,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+            )
+        """)
+
+        # Index for fast lookup by job_id
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_upscaled_videos_job_id ON upscaled_videos(job_id)
+        """)
+
         # Migrate from old schema if needed and always drop old tables
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='image_tag_associations'")
         if cursor.fetchone():
@@ -2213,3 +2233,98 @@ def add_tags_to_image(image_path: str, tag_names: List[str]) -> int:
             if add_tag_to_image(image_path, tag_name):
                 added += 1
     return added
+
+
+# ============== Upscaled Videos Functions ==============
+
+def create_upscaled_video(
+    job_id: int,
+    filename: str,
+    file_path: str,
+    scale: int,
+    model: str,
+    file_size: Optional[int] = None
+) -> int:
+    """Create a record for an upscaled video.
+
+    Args:
+        job_id: The job this upscaled video belongs to
+        filename: Just the filename (e.g., "video_upscaled_2x_20260112.mp4")
+        file_path: Full path to the file
+        scale: Upscale factor (2, 3, or 4)
+        model: Model used (e.g., "realesr-animevideov3")
+        file_size: File size in bytes (optional)
+
+    Returns:
+        The ID of the created record
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            INSERT INTO upscaled_videos (job_id, filename, file_path, scale, model, file_size, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (job_id, filename, file_path, scale, model, file_size, utc_now_iso()))
+        return cursor.lastrowid
+
+
+def get_upscaled_videos_for_job(job_id: int) -> List[Dict[str, Any]]:
+    """Get all upscaled videos for a job, ordered by creation time (newest first)."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT id, job_id, filename, file_path, scale, model, file_size, created_at
+            FROM upscaled_videos
+            WHERE job_id = ?
+            ORDER BY created_at DESC
+        """, (job_id,))
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_upscaled_video_by_id(video_id: int) -> Optional[Dict[str, Any]]:
+    """Get an upscaled video record by its ID."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT id, job_id, filename, file_path, scale, model, file_size, created_at
+            FROM upscaled_videos
+            WHERE id = ?
+        """, (video_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+
+def get_upscaled_video_by_filename(filename: str) -> Optional[Dict[str, Any]]:
+    """Get an upscaled video record by its filename."""
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT id, job_id, filename, file_path, scale, model, file_size, created_at
+            FROM upscaled_videos
+            WHERE filename = ?
+        """, (filename,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+
+def delete_upscaled_video(video_id: int) -> bool:
+    """Delete an upscaled video record by ID.
+
+    Note: This only deletes the database record, not the file itself.
+    Returns True if deleted, False if not found.
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM upscaled_videos WHERE id = ?", (video_id,))
+        return cursor.rowcount > 0
+
+
+def delete_upscaled_video_by_filename(filename: str) -> bool:
+    """Delete an upscaled video record by filename.
+
+    Note: This only deletes the database record, not the file itself.
+    Returns True if deleted, False if not found.
+    """
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM upscaled_videos WHERE filename = ?", (filename,))
+        return cursor.rowcount > 0

--- a/backend/migrations/add_upscaled_videos_table.py
+++ b/backend/migrations/add_upscaled_videos_table.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Migration script to add upscaled_videos table.
+
+Run this on production before deploying the new code:
+    cd backend
+    python migrations/add_upscaled_videos_table.py
+
+Or with custom database path:
+    DATABASE_PATH=/path/to/queue.db python migrations/add_upscaled_videos_table.py
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from database import DATABASE_PATH
+
+
+def migrate():
+    """Add upscaled_videos table to the database."""
+    print(f"Connecting to database: {DATABASE_PATH}")
+
+    if not os.path.exists(DATABASE_PATH):
+        print(f"ERROR: Database not found at {DATABASE_PATH}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+
+    # Check if table already exists
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='upscaled_videos'")
+    if cursor.fetchone():
+        print("Table 'upscaled_videos' already exists. Nothing to do.")
+        conn.close()
+        return
+
+    print("Creating upscaled_videos table...")
+    cursor.execute("""
+        CREATE TABLE upscaled_videos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id INTEGER NOT NULL,
+            filename TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            scale INTEGER NOT NULL,
+            model TEXT NOT NULL,
+            file_size INTEGER,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+        )
+    """)
+
+    print("Creating index on job_id...")
+    cursor.execute("""
+        CREATE INDEX idx_upscaled_videos_job_id ON upscaled_videos(job_id)
+    """)
+
+    conn.commit()
+    conn.close()
+
+    print("Migration complete!")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -61,7 +61,11 @@ from database import (
     add_tags_to_image as db_add_tags_to_image,
     remove_tag_from_image as db_remove_tag_from_image,
     get_all_used_tags_with_counts as db_get_all_used_tags_with_counts,
-    get_images_by_tag as db_get_images_by_tag
+    get_images_by_tag as db_get_images_by_tag,
+    create_upscaled_video as db_create_upscaled_video,
+    get_upscaled_videos_for_job as db_get_upscaled_videos_for_job,
+    get_upscaled_video_by_id as db_get_upscaled_video_by_id,
+    delete_upscaled_video as db_delete_upscaled_video
 )
 from comfyui_client import ComfyUIClient
 from queue_manager import queue_manager
@@ -2395,6 +2399,7 @@ async def upscale_job_video(job_id: int, scale: int = 2, model: str = "realesr-a
     """Upscale a job's final video.
 
     The job must be completed and have a final video.
+    The upscaled video is saved to the database for tracking.
     """
     job = get_job(job_id)
     if not job:
@@ -2421,106 +2426,82 @@ async def upscale_job_video(job_id: int, scale: int = 2, model: str = "realesr-a
     if result["status"] == "error":
         raise HTTPException(status_code=500, detail=result.get("error", "Upscaling failed"))
 
-    return result
-
-
-@router.get("/jobs/{job_id}/segments/{segment_index}/upscale")
-async def upscale_segment_video(job_id: int, segment_index: int, scale: int = 2, model: str = "realesr-animevideov3"):
-    """Upscale a specific segment's video."""
-    job = get_job(job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    segment = get_segment(job_id, segment_index)
-    if not segment:
-        raise HTTPException(status_code=404, detail="Segment not found")
-
-    if segment["status"] != "completed":
-        raise HTTPException(status_code=400, detail="Segment is not completed")
-
-    # Find the segment video
-    video_path = get_segment_video_path(job_id, segment_index, job.get("name", f"job_{job_id}"))
-
-    if not video_path or not os.path.exists(video_path):
-        raise HTTPException(status_code=404, detail="Segment video not found")
-
-    # Run upscaling (output_path=None lets upscale.py use UPSCALE_SAVE_PATH)
-    result = upscale_video(
-        input_path=video_path,
-        output_path=None,
-        scale=scale,
-        model=model
-    )
-
-    if result["status"] == "error":
-        raise HTTPException(status_code=500, detail=result.get("error", "Upscaling failed"))
+    # Save to database for tracking
+    output_path = result.get("output_path")
+    if output_path:
+        filename = Path(output_path).name
+        file_size = os.path.getsize(output_path) if os.path.exists(output_path) else None
+        db_create_upscaled_video(
+            job_id=job_id,
+            filename=filename,
+            file_path=output_path,
+            scale=scale,
+            model=model,
+            file_size=file_size
+        )
 
     return result
 
 
 @router.get("/jobs/{job_id}/upscaled-videos")
 async def list_upscaled_videos(job_id: int):
-    """List all upscaled videos for a job."""
+    """List all upscaled videos for a job from the database."""
     job = get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    if not UPSCALE_SAVE_PATH:
-        return {"videos": []}
+    # Get upscaled videos from database
+    db_videos = db_get_upscaled_videos_for_job(job_id)
 
-    upscale_dir = Path(UPSCALE_SAVE_PATH)
-    if not upscale_dir.exists():
-        return {"videos": []}
-
-    # Get job name and sanitize it for matching
-    job_name = job.get("name", f"job_{job_id}")
-    # Sanitize same way as video_utils does
-    sanitized_name = re.sub(r'[^\w\-.]', '_', job_name.replace(' ', '_'))
-
-    # Find all upscaled videos matching this job name
+    # Format response, checking if files still exist
     videos = []
-    for f in upscale_dir.glob(f"{sanitized_name}*_upscaled_*.mp4"):
-        stat = f.stat()
+    for v in db_videos:
+        file_exists = os.path.exists(v["file_path"]) if v.get("file_path") else False
         videos.append({
-            "filename": f.name,
-            "size": stat.st_size,
-            "created": stat.st_mtime,
-            "path": str(f)
+            "id": v["id"],
+            "filename": v["filename"],
+            "size": v.get("file_size") or 0,
+            "scale": v["scale"],
+            "model": v["model"],
+            "created": v["created_at"],
+            "exists": file_exists
         })
-
-    # Sort by creation time, newest first
-    videos.sort(key=lambda x: x["created"], reverse=True)
 
     return {"videos": videos}
 
 
-@router.delete("/upscaled-videos/{filename:path}")
-async def delete_upscaled_video(filename: str):
-    """Delete an upscaled video file."""
-    if not UPSCALE_SAVE_PATH:
-        raise HTTPException(status_code=400, detail="UPSCALE_SAVE_PATH not configured")
+@router.delete("/upscaled-videos/{video_id}")
+async def delete_upscaled_video_endpoint(video_id: int):
+    """Delete an upscaled video by its database ID.
 
-    # Security: only allow filenames, not paths
-    if "/" in filename or "\\" in filename or ".." in filename:
-        raise HTTPException(status_code=400, detail="Invalid filename")
+    Deletes both the file from disk and the database record.
+    """
+    # Get the record from database
+    video = db_get_upscaled_video_by_id(video_id)
+    if not video:
+        raise HTTPException(status_code=404, detail="Upscaled video not found")
 
-    upscale_dir = Path(UPSCALE_SAVE_PATH)
-    file_path = upscale_dir / filename
+    file_path = video.get("file_path")
+    filename = video.get("filename")
 
-    # Verify the file is within the upscale directory
-    try:
-        file_path.resolve().relative_to(upscale_dir.resolve())
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid file path")
+    # Delete the file if it exists
+    file_deleted = False
+    if file_path and os.path.exists(file_path):
+        try:
+            os.unlink(file_path)
+            file_deleted = True
+        except Exception as e:
+            # Log but continue - we still want to delete the DB record
+            print(f"Warning: Failed to delete file {file_path}: {e}")
 
-    if not file_path.exists():
-        raise HTTPException(status_code=404, detail="File not found")
+    # Delete from database
+    db_delete_upscaled_video(video_id)
 
-    try:
-        file_path.unlink()
-        return {"status": "success", "message": f"Deleted {filename}"}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to delete: {str(e)}")
+    return {
+        "status": "success",
+        "message": f"Deleted {filename}",
+        "file_deleted": file_deleted
+    }
 
 
 @router.get("/upscaled-videos/{filename:path}/download")

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -516,8 +516,8 @@ class APIClient {
     return this.request(`/jobs/${jobId}/upscaled-videos`);
   }
 
-  async deleteUpscaledVideo(filename) {
-    return this.request(`/upscaled-videos/${encodeURIComponent(filename)}`, {
+  async deleteUpscaledVideo(videoId) {
+    return this.request(`/upscaled-videos/${videoId}`, {
       method: 'DELETE'
     });
   }

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -402,11 +402,11 @@ export default function JobDetail() {
     }
   }
 
-  async function handleDeleteUpscaledVideo(filename) {
+  async function handleDeleteUpscaledVideo(videoId, filename) {
     if (!confirm(`Delete upscaled video "${filename}"?`)) return;
 
     try {
-      await API.deleteUpscaledVideo(filename);
+      await API.deleteUpscaledVideo(videoId);
       showToast('Upscaled video deleted', 'success');
       // Refresh the list
       const upscaledData = await API.getUpscaledVideos(id);
@@ -657,7 +657,7 @@ export default function JobDetail() {
                         variant="outlined"
                         size="small"
                         color="error"
-                        onClick={() => handleDeleteUpscaledVideo(video.filename)}
+                        onClick={() => handleDeleteUpscaledVideo(video.id, video.filename)}
                         sx={{ minWidth: 'auto', px: 1 }}
                       >
                         Delete


### PR DESCRIPTION
Previously, upscaled videos were associated with jobs by matching filenames against job names, which failed when multiple jobs had the same name. Now properly tracks upscaled videos in the database with job_id foreign key.

Changes:
- Add upscaled_videos table to database.py with CRUD functions
- Add migration script for production database
- Update POST /jobs/{id}/upscale to save to database after upscaling
- Update GET /jobs/{id}/upscaled-videos to query database
- Update DELETE /upscaled-videos/{id} to use database ID
- Remove segment upscale endpoint (only final videos can be upscaled)
- Update frontend to use video ID for delete operations