### PR TITLE
Fix fade-to-black reset when editing segment via modal

### DIFF
--- a/react-app/src/components/SubmitPromptModal.jsx
+++ b/react-app/src/components/SubmitPromptModal.jsx
@@ -29,6 +29,7 @@ export default function SubmitPromptModal({
   defaultPrompt = '',
   defaultLoras = [],  // Array of {high_file, high_weight, low_file, low_weight} pairs
   defaultFaceswap = null,  // {enabled, image, facesOrder, facesIndex} from previous segment or job
+  defaultFadeToBlack = false,  // Whether fade-to-black is enabled for this segment
   defaultStartImageUrl = null,  // URL of previous segment's end frame (for display)
   defaultCustomStartImage = null,  // Path of custom start image if already set
   isEditing = false,  // Whether editing an existing segment
@@ -55,6 +56,9 @@ export default function SubmitPromptModal({
   const [faceswapImage, setFaceswapImage] = useState(defaultFaceswap?.image || FACESWAP_FACES[0]?.value || '');
   const [faceswapFacesOrder, setFaceswapFacesOrder] = useState(defaultFaceswap?.facesOrder || 'left-right');
   const [faceswapFacesIndex, setFaceswapFacesIndex] = useState(defaultFaceswap?.facesIndex || '0');
+
+  // Fade to black state (initialized from defaults)
+  const [fadeToBlack, setFadeToBlack] = useState(defaultFadeToBlack);
 
   // Custom start image state (only for segments > 0)
   const [customStartImage, setCustomStartImage] = useState(defaultCustomStartImage);  // Path in image repo
@@ -224,7 +228,7 @@ export default function SubmitPromptModal({
         lorasArray,
         isEditing ? false : autoFinalize,  // Don't change auto-finalize when editing
         faceswapOptions,
-        false,  // fadeToBlack - not used here
+        fadeToBlack,
         customStartImage  // Custom start image path (or null for default)
       );
 
@@ -498,6 +502,22 @@ export default function SubmitPromptModal({
                 </div>
               </>
             )}
+          </div>
+
+          {/* Fade to Black */}
+          <div className="form-group">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={fadeToBlack}
+                  onChange={(e) => setFadeToBlack(e.target.checked)}
+                />
+              }
+              label="Apply fade to black transition at end"
+            />
+            <FormHelperText sx={{ ml: 4, mt: -1 }}>
+              2-second fade out/in effect when stitching with next segment
+            </FormHelperText>
           </div>
 
           {/* Auto Finalize - hide when editing existing segment */}

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -1402,6 +1402,7 @@ export default function JobDetail() {
           defaultPrompt={lastCompletedSegment?.prompt || ''}
           defaultLoras={buildDefaultLoras(lastCompletedSegment)}
           defaultFaceswap={buildDefaultFaceswap(lastCompletedSegment, job?.parameters)}
+          defaultFadeToBlack={false}
           defaultStartImageUrl={lastCompletedSegment?.end_frame_url || null}
           jobInputImage={job?.input_image}
           segments={segments}
@@ -1420,6 +1421,7 @@ export default function JobDetail() {
           defaultPrompt={editingSegment.prompt || ''}
           defaultLoras={buildDefaultLoras(editingSegment)}
           defaultFaceswap={buildDefaultFaceswap(editingSegment, job?.parameters)}
+          defaultFadeToBlack={Boolean(Number(editingSegment.fade_to_black))}
           defaultStartImageUrl={editingSegment.start_image_url || null}
           defaultCustomStartImage={editingSegment.custom_start_image || null}
           isEditing={true}


### PR DESCRIPTION
The SubmitPromptModal was hardcoded to send fadeToBlack=false, which reset any fade_to_black setting when editing a segment.

Changes:
- Add defaultFadeToBlack prop to SubmitPromptModal
- Add fadeToBlack state initialized from prop
- Add checkbox UI for fade-to-black above auto-finalize
- Pass current segment's fade_to_black when editing
- Default to false when creating new segments