### PR TITLE
Fix fade-to-black reset when editing segment via modal

### DIFF
--- a/backend/video_utils.py
+++ b/backend/video_utils.py
@@ -267,6 +267,9 @@ def stitch_videos(video_paths: List[str], output_path: str, segment_info: Option
     processed_paths = []
     temp_files = []
 
+    # Debug: log segment_info
+    print(f"[VideoUtils] stitch_videos called with {len(video_paths)} videos, segment_info={segment_info}")
+
     for i, video_path in enumerate(video_paths):
         # Check if this segment needs fade-out (has fade_to_black enabled)
         needs_fade_out = False
@@ -277,6 +280,8 @@ def stitch_videos(video_paths: List[str], output_path: str, segment_info: Option
         needs_fade_in = False
         if segment_info and i > 0 and i - 1 < len(segment_info):
             needs_fade_in = segment_info[i - 1].get("fade_to_black", False)
+
+        print(f"[VideoUtils] Segment {i}: fade_in={needs_fade_in}, fade_out={needs_fade_out}")
 
         if needs_fade_in or needs_fade_out:
             temp_path = video_path.replace(".mp4", "_faded.mp4")

--- a/react-app/src/components/SubmitPromptModal.jsx
+++ b/react-app/src/components/SubmitPromptModal.jsx
@@ -29,6 +29,7 @@ export default function SubmitPromptModal({
   defaultPrompt = '',
   defaultLoras = [],  // Array of {high_file, high_weight, low_file, low_weight} pairs
   defaultFaceswap = null,  // {enabled, image, facesOrder, facesIndex} from previous segment or job
+  defaultFadeToBlack = false,  // Whether fade-to-black is enabled for this segment
   defaultStartImageUrl = null,  // URL of previous segment's end frame (for display)
   defaultCustomStartImage = null,  // Path of custom start image if already set
   isEditing = false,  // Whether editing an existing segment
@@ -55,6 +56,9 @@ export default function SubmitPromptModal({
   const [faceswapImage, setFaceswapImage] = useState(defaultFaceswap?.image || FACESWAP_FACES[0]?.value || '');
   const [faceswapFacesOrder, setFaceswapFacesOrder] = useState(defaultFaceswap?.facesOrder || 'left-right');
   const [faceswapFacesIndex, setFaceswapFacesIndex] = useState(defaultFaceswap?.facesIndex || '0');
+
+  // Fade to black state (initialized from defaults)
+  const [fadeToBlack, setFadeToBlack] = useState(defaultFadeToBlack);
 
   // Custom start image state (only for segments > 0)
   const [customStartImage, setCustomStartImage] = useState(defaultCustomStartImage);  // Path in image repo
@@ -224,7 +228,7 @@ export default function SubmitPromptModal({
         lorasArray,
         isEditing ? false : autoFinalize,  // Don't change auto-finalize when editing
         faceswapOptions,
-        false,  // fadeToBlack - not used here
+        fadeToBlack,
         customStartImage  // Custom start image path (or null for default)
       );
 

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -1402,6 +1402,7 @@ export default function JobDetail() {
           defaultPrompt={lastCompletedSegment?.prompt || ''}
           defaultLoras={buildDefaultLoras(lastCompletedSegment)}
           defaultFaceswap={buildDefaultFaceswap(lastCompletedSegment, job?.parameters)}
+          defaultFadeToBlack={false}
           defaultStartImageUrl={lastCompletedSegment?.end_frame_url || null}
           jobInputImage={job?.input_image}
           segments={segments}
@@ -1420,6 +1421,7 @@ export default function JobDetail() {
           defaultPrompt={editingSegment.prompt || ''}
           defaultLoras={buildDefaultLoras(editingSegment)}
           defaultFaceswap={buildDefaultFaceswap(editingSegment, job?.parameters)}
+          defaultFadeToBlack={Boolean(Number(editingSegment.fade_to_black))}
           defaultStartImageUrl={editingSegment.start_image_url || null}
           defaultCustomStartImage={editingSegment.custom_start_image || null}
           isEditing={true}


### PR DESCRIPTION
The SubmitPromptModal was hardcoded to send fadeToBlack=false, which reset any fade_to_black setting when editing a segment.

Changes:
- Add defaultFadeToBlack prop to SubmitPromptModal (no UI checkbox)
- Add fadeToBlack state initialized from prop to preserve value
- Pass current segment's fade_to_black when editing
- Default to false when creating new segments
- Add debug logging to video_utils.py stitch_videos for troubleshooting