### PR TITLE
Refactor FPS system to target output FPS (30/60)

### DIFF
--- a/backend/comfyui_client.py
+++ b/backend/comfyui_client.py
@@ -321,19 +321,18 @@ class ComfyUIClient:
         negative_prompt: str = "",
         width: int = 640,
         height: int = 640,
-        frames: int = 81,
+        duration_sec: float = 5.0,
+        target_fps: int = 30,
         start_image_filename: str = "",
         high_noise_model: str = "wan2.2_i2v_high_noise_14B_fp16.safetensors",
         low_noise_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors",
         seed: Optional[int] = None,
         loras: Optional[List[Dict[str, str]]] = None,
-        fps: int = 16,
         output_prefix: str = "",
         faceswap_enabled: bool = False,
         faceswap_image: str = "",
         faceswap_faces_order: str = "left-right",
         faceswap_faces_index: str = "0",
-        frame_interpolation: str = "none",
     ) -> Dict[str, Any]:
         """Build a Wan2.2 i2v workflow using the pre-converted API template.
 
@@ -341,33 +340,33 @@ class ComfyUIClient:
         user values into the pre-converted workflow constant.
 
         Args:
-            loras: Optional list of LoRA pairs (max 2). Each dict has:
+            duration_sec: Video duration in seconds (default 5.0)
+            target_fps: Output fps - 30 or 60 (uses RIFE 2x or 4x interpolation)
+            loras: Optional list of LoRA pairs (max 3). Each dict has:
                    - high_file: LoRA filename for high noise pass
                    - low_file: LoRA filename for low noise pass
             faceswap_enabled: Whether to enable face swapping via ReActor
             faceswap_image: Filename of the face image to swap in
             faceswap_faces_order: Order to process faces (left-right, right-left, etc.)
             faceswap_faces_index: Which face indices to process (e.g., "0", "0,1")
-            frame_interpolation: Frame interpolation mode - "none" or "2x" (RIFE)
         """
         return _build_wan_i2v_workflow(
             prompt=prompt,
             negative_prompt=negative_prompt,
             width=width,
             height=height,
-            frames=frames,
+            duration_sec=duration_sec,
+            target_fps=target_fps,
             start_image_filename=start_image_filename,
             high_noise_model=high_noise_model,
             low_noise_model=low_noise_model,
             seed=seed,
             loras=loras,
-            fps=fps,
             output_prefix=output_prefix,
             faceswap_enabled=faceswap_enabled,
             faceswap_image=faceswap_image,
             faceswap_faces_order=faceswap_faces_order,
             faceswap_faces_index=faceswap_faces_index,
-            frame_interpolation=frame_interpolation,
         )
 
     def build_workflow(
@@ -385,7 +384,8 @@ class ComfyUIClient:
         seed: Optional[int] = None,
         denoise: float = 0.75,
         input_image: Optional[str] = None,
-        frames: int = 81,
+        duration_sec: float = 5.0,
+        target_fps: int = 30,
         high_noise_model: str = "wan2.2_i2v_high_noise_14B_fp16.safetensors",
         low_noise_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors",
     ) -> Dict[str, Any]:
@@ -401,7 +401,8 @@ class ComfyUIClient:
                 negative_prompt=negative_prompt,
                 width=width,
                 height=height,
-                frames=frames,
+                duration_sec=duration_sec,
+                target_fps=target_fps,
                 start_image_filename=input_image or "",
                 high_noise_model=high_noise_model,
                 low_noise_model=low_noise_model,

--- a/backend/config.py
+++ b/backend/config.py
@@ -6,9 +6,8 @@ COMFYUI_SERVER_URL = "http://localhost:8188"
 # Default Generation Parameters
 DEFAULT_WIDTH = 512
 DEFAULT_HEIGHT = 768
-DEFAULT_FPS = 16
-DEFAULT_FRAME_INTERPOLATION = "2x"  # "none" or "2x" (RIFE)
-DEFAULT_FRAMES_PER_SEGMENT = 81  # 5 seconds at 16 FPS
+DEFAULT_TARGET_FPS = 30  # Output fps: 30 or 60 (uses RIFE 2x or 4x interpolation)
+GENERATION_FPS = 15  # Internal: base fps before RIFE interpolation
 
 # Model Names
 # Note: Update these to match the models available on your ComfyUI server

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -459,9 +459,8 @@ class QueueManager:
         
         # Get job parameters
         params = job.get("parameters") or {}
-        fps = int(params.get("fps", get_setting("default_fps", "16")))
-        segment_duration = int(params.get("segment_duration", 5))
-        frames = fps * segment_duration + 1
+        target_fps = int(params.get("target_fps", get_setting("default_target_fps", "30")))
+        segment_duration = float(params.get("segment_duration", 5))
         
         # Determine the start image for this segment
         # Check for custom start image first (overrides default behavior)
@@ -616,9 +615,6 @@ class QueueManager:
         faceswap_faces_order = segment.get("faceswap_faces_order", "left-right") or "left-right"
         faceswap_faces_index = segment.get("faceswap_faces_index", "0") or "0"
 
-        # Get frame interpolation setting (default to 2x for smoother video)
-        frame_interpolation = params.get("frame_interpolation", "2x")
-
         # Use the job's seed for all segments (fixed seed per job)
         job_seed = job.get("seed")
         if job_seed is not None:
@@ -629,25 +625,24 @@ class QueueManager:
             negative_prompt=job.get("negative_prompt", get_setting("default_negative_prompt", "")),
             width=int(params.get("width", get_setting("default_width", "640"))),
             height=int(params.get("height", get_setting("default_height", "640"))),
-            frames=frames,
+            duration_sec=segment_duration,
+            target_fps=target_fps,
             start_image_filename=input_image,
             high_noise_model=get_setting("high_noise_model", "wan2.2_i2v_high_noise_14B_fp16.safetensors"),
             low_noise_model=get_setting("low_noise_model", "wan2.2_i2v_low_noise_14B_fp16.safetensors"),
             seed=job_seed,
             loras=loras if loras else None,
-            fps=fps,
             output_prefix=output_prefix,
             faceswap_enabled=faceswap_enabled,
             faceswap_image=faceswap_image,
             faceswap_faces_order=faceswap_faces_order,
             faceswap_faces_index=faceswap_faces_index,
-            frame_interpolation=frame_interpolation,
         )
 
         # Queue the prompt
         logger.info(f"[Job {job_id}] Queuing segment {segment_index} workflow to ComfyUI...")
         add_job_log(job_id, "INFO", f"Queuing segment {segment_index} to ComfyUI", segment_index=segment_index,
-                   details=f"image={input_image}, {params.get('width', 640)}x{params.get('height', 640)}, {frames} frames")
+                   details=f"image={input_image}, {params.get('width', 640)}x{params.get('height', 640)}, {segment_duration}s @ {target_fps}fps")
         success, result = client.queue_prompt(workflow)
         logger.info(f"[Job {job_id}] queue_prompt result: success={success}, result={result[:200] if isinstance(result, str) else result}")
 
@@ -657,8 +652,8 @@ class QueueManager:
                 "prompt": (segment.get("prompt") or job.get("prompt", ""))[:100] + "...",
                 "input_image": input_image,
                 "dimensions": f"{params.get('width', 640)}x{params.get('height', 640)}",
-                "frames": frames,
-                "fps": fps,
+                "duration_sec": segment_duration,
+                "target_fps": target_fps,
                 "loras": loras,
             }
             logger.error(f"[Job {job_id}] Segment {segment_index} FAILED to queue!")
@@ -973,11 +968,10 @@ class QueueManager:
     def _process_single_segment_job(self, job_id: int, job: dict, client: ComfyUIClient):
         """Process a job as a single segment (legacy behavior)."""
         print(f"[QueueManager] Processing job {job_id} as single segment")
-        
+
         params = job.get("parameters") or {}
-        fps = int(params.get("fps", get_setting("default_fps", "16")))
-        segment_duration = int(params.get("segment_duration", 5))
-        frames = fps * segment_duration + 1
+        target_fps = int(params.get("target_fps", get_setting("default_target_fps", "30")))
+        segment_duration = float(params.get("segment_duration", 5))
 
         # Check if ComfyUI queue is idle before submitting
         queue_status = client.get_queue_status()
@@ -1078,7 +1072,8 @@ class QueueManager:
             seed=job_seed,
             denoise=float(params.get("denoise", 0.75)),
             input_image=job.get("input_image"),
-            frames=frames,
+            duration_sec=segment_duration,
+            target_fps=target_fps,
             high_noise_model=get_setting("high_noise_model", "wan2.2_i2v_high_noise_14B_fp16.safetensors"),
             low_noise_model=get_setting("low_noise_model", "wan2.2_i2v_low_noise_14B_fp16.safetensors"),
         )

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -74,8 +74,7 @@ from config import (
     COMFYUI_SERVER_URL,
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
-    DEFAULT_FPS,
-    DEFAULT_FRAME_INTERPOLATION,
+    DEFAULT_TARGET_FPS,
     MODELS,
     GENERATION_PARAMS,
     DEFAULT_NEGATIVE_PROMPT
@@ -1294,8 +1293,7 @@ async def get_settings():
     settings.setdefault("comfyui_url", COMFYUI_SERVER_URL)
     settings.setdefault("default_width", str(DEFAULT_WIDTH))
     settings.setdefault("default_height", str(DEFAULT_HEIGHT))
-    settings.setdefault("default_fps", str(DEFAULT_FPS))
-    settings.setdefault("default_frame_interpolation", DEFAULT_FRAME_INTERPOLATION)
+    settings.setdefault("default_target_fps", str(DEFAULT_TARGET_FPS))
     settings.setdefault("default_negative_prompt", DEFAULT_NEGATIVE_PROMPT)
     settings.setdefault("models", MODELS)
     settings.setdefault("generation_params", GENERATION_PARAMS)

--- a/backend/workflow_templates.py
+++ b/backend/workflow_templates.py
@@ -197,24 +197,55 @@ def _sanitize_filename(name: str) -> str:
     return safe.strip('_')
 
 
+# Generation FPS is fixed at 15fps - RIFE interpolation brings it to target fps
+GENERATION_FPS = 15
+
+
+def calculate_generation_params(target_fps: int, duration_sec: float) -> Dict[str, Any]:
+    """Calculate internal generation parameters from user-facing target fps.
+
+    Args:
+        target_fps: User-selected output fps (30 or 60)
+        duration_sec: Video duration in seconds
+
+    Returns:
+        Dict with:
+        - generation_fps: Base fps before interpolation (always 15)
+        - wan_frames: Number of frames for WanImageToVideo node
+        - rife_multiplier: RIFE interpolation factor (2 for 30fps, 4 for 60fps)
+        - output_fps: Final output fps (same as target_fps)
+    """
+    # Calculate RIFE multiplier to reach target fps from 15fps base
+    rife_multiplier = target_fps // GENERATION_FPS  # 30/15=2, 60/15=4
+
+    # Calculate frames for Wan generation (at 15fps)
+    wan_frames = int(duration_sec * GENERATION_FPS) + 1
+
+    return {
+        "generation_fps": GENERATION_FPS,
+        "wan_frames": wan_frames,
+        "rife_multiplier": rife_multiplier,
+        "output_fps": target_fps,
+    }
+
+
 def build_wan_i2v_workflow(
     prompt: str,
     negative_prompt: str = "",
     width: int = 640,
     height: int = 640,
-    frames: int = 81,
+    duration_sec: float = 5.0,
+    target_fps: int = 30,
     start_image_filename: str = "",
     high_noise_model: str = "wan2.2_i2v_high_noise_14B_fp16.safetensors",
     low_noise_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors",
     seed: Optional[int] = None,
     loras: Optional[List[Dict[str, str]]] = None,
-    fps: int = 16,
     output_prefix: str = "",
     faceswap_enabled: bool = False,
     faceswap_image: str = "",
     faceswap_faces_order: str = "left-right",
     faceswap_faces_index: str = "0",
-    frame_interpolation: str = "none",
 ) -> Dict[str, Any]:
     """Build a Wan2.2 i2v workflow by injecting values into the pre-converted template.
 
@@ -223,7 +254,8 @@ def build_wan_i2v_workflow(
         negative_prompt: Negative prompt (things to avoid)
         width: Video width in pixels
         height: Video height in pixels
-        frames: Number of frames to generate
+        duration_sec: Video duration in seconds (default 5.0)
+        target_fps: Output fps - 30 or 60 (uses RIFE 2x or 4x interpolation)
         start_image_filename: Filename of the uploaded start image
         high_noise_model: UNET model for high noise pass
         low_noise_model: UNET model for low noise pass
@@ -232,15 +264,20 @@ def build_wan_i2v_workflow(
                - high_file: LoRA filename for high noise pass
                - low_file: LoRA filename for low noise pass
                If empty/None, no user LoRAs are applied (only lightx2v acceleration)
-        fps: Frames per second for output video (default 16)
         output_prefix: Filename prefix for output video (sanitized job name)
         faceswap_enabled: Whether to enable face swapping via ReActor
         faceswap_image: Filename of the face image to swap in (in ComfyUI input folder)
-        frame_interpolation: Frame interpolation mode - "none" or "2x" (RIFE)
 
     Returns:
         ComfyUI API workflow dict ready to submit
     """
+    # Calculate generation parameters from target fps
+    gen_params = calculate_generation_params(target_fps, duration_sec)
+    frames = gen_params["wan_frames"]
+    generation_fps = gen_params["generation_fps"]
+    rife_multiplier = gen_params["rife_multiplier"]
+    output_fps = gen_params["output_fps"]
+    print(f"[Workflow] Target {target_fps}fps: generating {frames} frames @ {generation_fps}fps, RIFE {rife_multiplier}x → {output_fps}fps")
     # Deep copy the template so we don't modify the original
     workflow = copy.deepcopy(WAN_I2V_API_WORKFLOW)
 
@@ -336,9 +373,10 @@ def build_wan_i2v_workflow(
     else:
         print("[Workflow] No user LoRAs selected (using only lightx2v acceleration)")
 
-    # Override FPS (node 94 - CreateVideo)
-    workflow["94"]["inputs"]["fps"] = fps
-    print(f"[Workflow] Set FPS: {fps}")
+    # Note: FPS for the base CreateVideo node is set to generation_fps
+    # This may be overwritten below when RIFE is added (which uses VHS_VideoCombine instead)
+    workflow["94"]["inputs"]["fps"] = generation_fps
+    print(f"[Workflow] Set base FPS: {generation_fps}")
 
     # Override output filename prefix
     safe_prefix = _sanitize_filename(output_prefix) if output_prefix else "ComfyUI"
@@ -393,11 +431,11 @@ def build_wan_i2v_workflow(
         }
 
         # Add VHS_VideoCombine node (node 186)
-        # Combines face-swapped frames into video
+        # Combines face-swapped frames into video (fps updated below with RIFE)
         workflow["186"] = {
             "class_type": "VHS_VideoCombine",
             "inputs": {
-                "frame_rate": fps,
+                "frame_rate": output_fps,  # Will be target fps after RIFE
                 "loop_count": 0,
                 "filename_prefix": safe_prefix,
                 "format": "video/h264-mp4",
@@ -407,72 +445,65 @@ def build_wan_i2v_workflow(
                 "trim_to_audio": False,
                 "pingpong": False,
                 "save_output": True,
-                "images": ["183", 0]  # Face-swapped frames from ReActor
+                "images": ["183", 0]  # Face-swapped frames from ReActor (rewired below for RIFE)
             },
             "_meta": {"title": "Video Combine (Faceswap)"}
         }
 
         print(f"[Workflow] Added faceswap nodes: 188 (LoadImage), 183 (ReActor), 186 (VHS_VideoCombine)")
         print(f"[Workflow] Removed node 108 (SaveVideo)")
+
+    # Always add RIFE frame interpolation (required for both 30fps and 60fps output)
+    print(f"[Workflow] Adding RIFE {rife_multiplier}x frame interpolation")
+
+    # Add RIFE VFI node (node 200)
+    workflow["200"] = {
+        "class_type": "RIFE VFI",
+        "inputs": {
+            "ckpt_name": "rife49.pth",  # rife49 has better quality, less VRAM than rife47
+            "clear_cache_after_n_frames": 10,  # Clear frequently to reduce system RAM usage
+            "multiplier": rife_multiplier,  # 2 for 30fps, 4 for 60fps
+            "fast_mode": True,  # Ignored in v4.5+ but kept for compatibility
+            "ensemble": True,
+            "scale_factor": 1,
+            # frames input will be wired below
+        },
+        "_meta": {"title": f"RIFE {rife_multiplier}x Interpolation"}
+    }
+
+    if faceswap_enabled:
+        # With faceswap: 183 (ReActor) → 200 (RIFE) → 186 (VHS_VideoCombine)
+        workflow["200"]["inputs"]["frames"] = ["183", 0]
+        workflow["186"]["inputs"]["images"] = ["200", 0]
+        workflow["186"]["inputs"]["frame_rate"] = output_fps
+        print(f"[Workflow] RIFE wired: ReActor(183) → RIFE(200) → VHS_VideoCombine(186) @ {output_fps}fps ({rife_multiplier}x interpolated)")
     else:
-        # Standard output via SaveVideo (node 108)
-        workflow["108"]["inputs"]["filename_prefix"] = safe_prefix
-        print(f"[Workflow] Set output prefix: {safe_prefix}")
+        # Without faceswap: use VHS_VideoCombine instead of CreateVideo+SaveVideo
+        # Remove CreateVideo and SaveVideo nodes
+        del workflow["94"]
+        del workflow["108"]
 
-    # Add RIFE frame interpolation if enabled
-    # "2x" doubles frames AND doubles fps, maintaining original duration with smoother motion
-    if frame_interpolation == "2x":
-        print(f"[Workflow] Adding RIFE 2x frame interpolation")
-        output_fps = fps * 2  # Double fps to maintain duration with interpolated frames
-
-        # Add RIFE VFI node (node 200)
-        workflow["200"] = {
-            "class_type": "RIFE VFI",
+        # Add VHS_VideoCombine node (node 186)
+        workflow["186"] = {
+            "class_type": "VHS_VideoCombine",
             "inputs": {
-                "ckpt_name": "rife49.pth",  # rife49 has better quality, less VRAM than rife47
-                "clear_cache_after_n_frames": 25,  # Clear more frequently to reduce system RAM usage
-                "multiplier": 2,
-                "fast_mode": True,  # Ignored in v4.5+ but kept for compatibility
-                "ensemble": True,
-                "scale_factor": 1,
-                # frames input will be wired below
+                "frame_rate": output_fps,
+                "loop_count": 0,
+                "filename_prefix": safe_prefix,
+                "format": "video/h264-mp4",
+                "pix_fmt": "yuv420p",
+                "crf": 15,
+                "save_metadata": True,
+                "trim_to_audio": False,
+                "pingpong": False,
+                "save_output": True,
+                "images": ["200", 0]  # From RIFE output
             },
-            "_meta": {"title": "RIFE Frame Interpolation"}
+            "_meta": {"title": "Video Combine (RIFE)"}
         }
 
-        if faceswap_enabled:
-            # With faceswap: 183 (ReActor) → 200 (RIFE) → 186 (VHS_VideoCombine)
-            workflow["200"]["inputs"]["frames"] = ["183", 0]
-            workflow["186"]["inputs"]["images"] = ["200", 0]
-            workflow["186"]["inputs"]["frame_rate"] = output_fps  # Doubled fps for same duration
-            print(f"[Workflow] RIFE wired: ReActor(183) → RIFE(200) → VHS_VideoCombine(186) @ {output_fps}fps (2x interpolated)")
-        else:
-            # Without faceswap + RIFE: use VHS_VideoCombine instead of CreateVideo+SaveVideo
-            # Remove CreateVideo and SaveVideo nodes
-            del workflow["94"]
-            del workflow["108"]
-
-            # Add VHS_VideoCombine node (node 186)
-            workflow["186"] = {
-                "class_type": "VHS_VideoCombine",
-                "inputs": {
-                    "frame_rate": output_fps,  # Doubled fps for same duration
-                    "loop_count": 0,
-                    "filename_prefix": safe_prefix,
-                    "format": "video/h264-mp4",
-                    "pix_fmt": "yuv420p",
-                    "crf": 15,
-                    "save_metadata": True,
-                    "trim_to_audio": False,
-                    "pingpong": False,
-                    "save_output": True,
-                    "images": ["200", 0]  # From RIFE output
-                },
-                "_meta": {"title": "Video Combine (RIFE)"}
-            }
-
-            # Wire: VAEDecode(87) → RIFE(200) → VHS_VideoCombine(186)
-            workflow["200"]["inputs"]["frames"] = ["87", 0]
-            print(f"[Workflow] RIFE wired: VAEDecode(87) → RIFE(200) → VHS_VideoCombine(186) @ {output_fps}fps (2x interpolated)")
+        # Wire: VAEDecode(87) → RIFE(200) → VHS_VideoCombine(186)
+        workflow["200"]["inputs"]["frames"] = ["87", 0]
+        print(f"[Workflow] RIFE wired: VAEDecode(87) → RIFE(200) → VHS_VideoCombine(186) @ {output_fps}fps ({rife_multiplier}x interpolated)")
 
     return workflow

--- a/react-app/src/components/CreateJobModal.jsx
+++ b/react-app/src/components/CreateJobModal.jsx
@@ -30,7 +30,7 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
   const [prompt, setPrompt] = useState('');
   const [width, setWidth] = useState(640);
   const [height, setHeight] = useState(640);
-  const [fps, setFps] = useState(16);
+  const [targetFps, setTargetFps] = useState(30);
   const [segmentDuration, setSegmentDuration] = useState(5);
   const [imageFile, setImageFile] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
@@ -50,7 +50,6 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
   const [selectedPrefix, setSelectedPrefix] = useState(null);
   const [selectedDescription, setSelectedDescription] = useState(null);
   const [autoFinalize, setAutoFinalize] = useState(false);
-  const [frameInterpolation, setFrameInterpolation] = useState('2x');
 
   useEffect(() => {
     console.log('[CreateJobModal] useEffect running with:', { preUploadedImageUrl, preUploadedDimensions, cloneData });
@@ -78,9 +77,19 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
         setPrompt(cloneData.prompt || '');
         setWidth(cloneData.width || cloneData.parameters?.width || 640);
         setHeight(cloneData.height || cloneData.parameters?.height || 640);
-        setFps(cloneData.fps || cloneData.parameters?.fps || 16);
         setSegmentDuration(cloneData.segment_duration || cloneData.parameters?.segment_duration || 5);
-        setFrameInterpolation(cloneData.parameters?.frame_interpolation || '2x');
+
+        // Handle target_fps (new) or calculate from legacy fps + frame_interpolation
+        if (cloneData.parameters?.target_fps) {
+          setTargetFps(cloneData.parameters.target_fps);
+        } else {
+          // Legacy job: calculate effective output fps
+          const legacyFps = cloneData.fps || cloneData.parameters?.fps || 16;
+          const legacyInterp = cloneData.parameters?.frame_interpolation || '2x';
+          const effectiveFps = legacyInterp === '2x' ? legacyFps * 2 : legacyFps;
+          // Map to nearest supported target fps (30 or 60)
+          setTargetFps(effectiveFps >= 45 ? 60 : 30);
+        }
 
         // Copy faceswap settings
         if (cloneData.parameters?.faceswap_enabled) {
@@ -176,18 +185,14 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
       console.log('[CreateJobModal] API.getSettings() returned:', data);
       const s = data.settings || data;
       console.log('[CreateJobModal] Parsed settings:', s);
-      console.log('[CreateJobModal] default_width:', s.default_width, 'type:', typeof s.default_width);
-      console.log('[CreateJobModal] default_height:', s.default_height, 'type:', typeof s.default_height);
-      console.log('[CreateJobModal] default_fps:', s.default_fps, 'type:', typeof s.default_fps);
       setSettings(s);
       const newWidth = parseInt(s.default_width) || 640;
       const newHeight = parseInt(s.default_height) || 640;
-      const newFps = parseInt(s.default_fps) || 16;
-      console.log('[CreateJobModal] Setting width:', newWidth, 'height:', newHeight, 'fps:', newFps);
+      const newTargetFps = parseInt(s.default_target_fps) || 30;
+      console.log('[CreateJobModal] Setting width:', newWidth, 'height:', newHeight, 'targetFps:', newTargetFps);
       setWidth(newWidth);
       setHeight(newHeight);
-      setFps(newFps);
-      setFrameInterpolation(s.default_frame_interpolation || '2x');
+      setTargetFps(newTargetFps);
 
       // Parse job naming presets
       try {
@@ -328,14 +333,13 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
         parameters: {
           width,
           height,
-          fps,
+          target_fps: targetFps,
           segment_duration: segmentDuration,
           faceswap_enabled: faceswapEnabled,
           faceswap_image: faceswapEnabled ? faceswapImage : null,
           faceswap_faces_order: faceswapEnabled ? faceswapFacesOrder : null,
           faceswap_faces_index: faceswapEnabled ? faceswapFacesIndex : null,
-          auto_finalize: autoFinalize,
-          frame_interpolation: frameInterpolation
+          auto_finalize: autoFinalize
         }
       };
 
@@ -434,22 +438,11 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
                 <MenuItem value={10}>10 sec</MenuItem>
               </Select>
             </FormControl>
-            <FormControl variant="outlined" size="small" sx={{ width: '100px' }}>
-              <InputLabel>FPS</InputLabel>
-              <Select value={fps} onChange={(e) => setFps(parseInt(e.target.value))} label="FPS">
-                <MenuItem value={8}>8</MenuItem>
-                <MenuItem value={12}>12</MenuItem>
-                <MenuItem value={16}>16</MenuItem>
-                <MenuItem value={20}>20</MenuItem>
-                <MenuItem value={24}>24</MenuItem>
-                <MenuItem value={32}>32</MenuItem>
-              </Select>
-            </FormControl>
             <FormControl variant="outlined" size="small" sx={{ width: '120px' }}>
-              <InputLabel>Interpolation</InputLabel>
-              <Select value={frameInterpolation} onChange={(e) => setFrameInterpolation(e.target.value)} label="Interpolation">
-                <MenuItem value="none">None</MenuItem>
-                <MenuItem value="2x">2x</MenuItem>
+              <InputLabel>Output FPS</InputLabel>
+              <Select value={targetFps} onChange={(e) => setTargetFps(parseInt(e.target.value))} label="Output FPS">
+                <MenuItem value={30}>30 fps</MenuItem>
+                <MenuItem value={60}>60 fps</MenuItem>
               </Select>
             </FormControl>
           </div>

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -494,7 +494,13 @@ export default function JobDetail() {
   const width = job.width ?? params.width ?? 640;
   const height = job.height ?? params.height ?? 640;
   const segmentDuration = job.segment_duration ?? params.segment_duration ?? 5;
-  const fps = job.fps ?? params.fps ?? 16;
+
+  // Calculate display fps: new jobs have target_fps, legacy jobs have fps + frame_interpolation
+  const displayFps = params.target_fps
+    ? `${params.target_fps} fps`
+    : params.frame_interpolation === '2x'
+      ? `${(params.fps || 16) * 2} fps (legacy)`
+      : `${params.fps || 16} fps (legacy)`;
 
   // Format time as mm:ss or hh:mm:ss
   function formatExecutionTime(seconds) {
@@ -762,8 +768,8 @@ export default function JobDetail() {
             <div className="value">{segmentDuration}s per segment</div>
           </div>
           <div className="detail-meta-item">
-            <label>FPS / RIFE</label>
-            <div className="value">{fps} fps / {params.frame_interpolation === '2x' ? '2x' : 'None'}</div>
+            <label>Output FPS</label>
+            <div className="value">{displayFps}</div>
           </div>
           <div className="detail-meta-item">
             <label>Seed</label>

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -18,7 +18,7 @@ export default function Settings() {
   const [imageRepoPath, setImageRepoPath] = useState('');
   const [defaultWidth, setDefaultWidth] = useState(640);
   const [defaultHeight, setDefaultHeight] = useState(640);
-  const [defaultFps, setDefaultFps] = useState(16);
+  const [defaultTargetFps, setDefaultTargetFps] = useState(30);
   const [defaultNegativePrompt, setDefaultNegativePrompt] = useState('');
   const [queueWaitTimeout, setQueueWaitTimeout] = useState(30);
   const [segmentExecutionTimeout, setSegmentExecutionTimeout] = useState(20);
@@ -43,7 +43,7 @@ export default function Settings() {
       setImageRepoPath(s.image_repo_path || '');
       setDefaultWidth(parseInt(s.default_width) || 640);
       setDefaultHeight(parseInt(s.default_height) || 640);
-      setDefaultFps(parseInt(s.default_fps) || 16);
+      setDefaultTargetFps(parseInt(s.default_target_fps) || 30);
       setDefaultNegativePrompt(s.default_negative_prompt || 'blurry, low quality, distorted');
       setQueueWaitTimeout(Math.round((parseInt(s.queue_wait_timeout) || 1800) / 60)); // Convert seconds to minutes
       setSegmentExecutionTimeout(Math.round((parseInt(s.segment_execution_timeout) || 1200) / 60)); // Convert seconds to minutes
@@ -126,7 +126,7 @@ export default function Settings() {
         image_repo_path: imageRepoPath,
         default_width: String(defaultWidth),
         default_height: String(defaultHeight),
-        default_fps: String(defaultFps),
+        default_target_fps: String(defaultTargetFps),
         default_negative_prompt: defaultNegativePrompt,
         queue_wait_timeout: String(queueWaitTimeout * 60), // Convert minutes to seconds
         segment_execution_timeout: String(segmentExecutionTimeout * 60), // Convert minutes to seconds
@@ -429,14 +429,14 @@ export default function Settings() {
               />
             </div>
             <div className="form-group">
-              <label>FPS</label>
-              <input
-                type="number"
-                value={defaultFps}
-                onChange={(e) => setDefaultFps(parseInt(e.target.value))}
-                min="1"
-                max="60"
-              />
+              <label>Output FPS</label>
+              <select
+                value={defaultTargetFps}
+                onChange={(e) => setDefaultTargetFps(parseInt(e.target.value))}
+              >
+                <option value={30}>30 fps</option>
+                <option value={60}>60 fps</option>
+              </select>
             </div>
           </div>
           <div className="form-group">


### PR DESCRIPTION
Replace confusing FPS + Interpolation dropdowns with single Output FPS dropdown.

Backend changes:
- Add calculate_generation_params() to compute internal generation parameters
- Update build_wan_i2v_workflow() signature: duration_sec + target_fps instead of frames + fps + frame_interpolation
- Always use RIFE interpolation (2x for 30fps, 4x for 60fps) with 15fps base generation
- Update queue_manager.py to use new workflow signature
- Update settings to use default_target_fps instead of default_fps + default_frame_interpolation

Frontend changes:
- CreateJobModal: Replace FPS (8-32) + Interpolation (None/2x) with Output FPS (30/60)
- JobDetail: Update display to show output FPS with legacy fallback
- Settings: Update default FPS setting to be Output FPS dropdown

Backward compatibility:
- Legacy jobs with fps + frame_interpolation display as "X fps (legacy)"
- Clone legacy jobs maps to nearest target fps (30 or 60)

Closes #158