### PR TITLE
Add FFmpeg remux post-processing to fix VHS_VideoCombine duration met…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,7 @@ from routes import router
 from queue_manager import queue_manager
 from comfyui_client import ComfyUIClient
 from progress_tracker import progress_tracker
-from video_utils import download_video_from_comfyui, extract_last_frame, get_segment_video_path, get_segment_frame_path
+from video_utils import download_video_from_comfyui, extract_last_frame, remux_video, get_segment_video_path, get_segment_frame_path
 
 
 def recover_segment_from_comfyui(segment: dict, client: ComfyUIClient, comfyui_url: str):
@@ -51,6 +51,9 @@ def recover_segment_from_comfyui(segment: dict, client: ComfyUIClient, comfyui_u
         print(f"[Recovery] Failed to download video for segment {segment_index} of job {job_id}")
         update_segment_status(job_id, segment_index, "failed", error_message="Recovery failed: video download failed")
         return False
+
+    # Remux to fix duration metadata (VHS_VideoCombine issue)
+    remux_video(video_path)
 
     # Extract last frame
     frame_path = get_segment_frame_path(job_id, segment_index, "last")

--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -34,6 +34,7 @@ from progress_tracker import progress_tracker
 from video_utils import (
     download_video_from_comfyui,
     extract_last_frame,
+    remux_video,
     stitch_videos,
     get_segment_video_path,
     get_segment_frame_path,
@@ -748,6 +749,8 @@ class QueueManager:
                     print(f"[QueueManager] Downloading video from {video_url} to {video_path}")
                     if download_video_from_comfyui(video_url, video_path):
                         print(f"[QueueManager] Video downloaded successfully")
+                        # Remux to fix duration metadata (VHS_VideoCombine issue)
+                        remux_video(video_path)
                         # Extract the last frame
                         frame_path = get_segment_frame_path(job_id, segment_index, "last")
                         print(f"[QueueManager] Extracting last frame to {frame_path}")

--- a/backend/video_utils.py
+++ b/backend/video_utils.py
@@ -17,6 +17,42 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 print(f"[VideoUtils] Output directory: {OUTPUT_DIR}")
 
 
+def remux_video(input_path: str) -> str:
+    """Remux a video to fix missing duration metadata.
+
+    VHS_VideoCombine outputs videos without proper duration metadata.
+    This remux operation rewrites the container without re-encoding,
+    which fixes the duration metadata issue.
+
+    Args:
+        input_path: Path to the input video file
+
+    Returns:
+        The input path (modified in-place) on success, or original path on failure
+    """
+    temp_path = input_path + ".remux.mp4"
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-y", "-i", input_path, "-c", "copy", temp_path],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode == 0 and os.path.exists(temp_path):
+            os.replace(temp_path, input_path)
+            print(f"[VideoUtils] Remuxed video to fix duration metadata: {input_path}")
+            return input_path
+        else:
+            print(f"[VideoUtils] Remux warning: {result.stderr}")
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+            return input_path
+    except Exception as e:
+        print(f"[VideoUtils] Remux error (non-fatal): {e}")
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+        return input_path
+
+
 def optimize_video_for_web(video_path: str) -> bool:
     """Optimize an MP4 video for web streaming by moving moov atom to start.
 


### PR DESCRIPTION
…adata

VHS_VideoCombine outputs videos without proper duration metadata, causing issues with video players and ffprobe. This adds a remux step immediately after downloading each segment video from ComfyUI.

The remux uses `ffmpeg -c copy` to rewrite the container without re-encoding, which properly populates the duration metadata. The operation is non-fatal - if it fails, the original video is preserved and processing continues.

Fixes #160