### PR TITLE
Remove dead legacy upscaled video endpoint

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -887,50 +887,6 @@ async def get_job_video(job_id: int):
     )
 
 
-@router.get("/jobs/{job_id}/video/upscaled")
-async def get_job_video_upscaled(job_id: int):
-    """Get the upscaled video for a completed job.
-
-    Returns the upscaled video file if it exists.
-    """
-    job = get_job(job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    # Check if job has output videos
-    output_images = job.get("output_images") or []
-    if not output_images:
-        raise HTTPException(status_code=404, detail="No video available")
-
-    # Get the original video path
-    video_path = output_images[0] if output_images else None
-    if not video_path:
-        raise HTTPException(status_code=404, detail="No video path found")
-
-    # Construct upscaled video path (check for 2x upscaled)
-    video_stem = Path(video_path).stem
-    video_dir = Path(video_path).parent
-    upscaled_path = video_dir / f"{video_stem}_upscaled_2x.mp4"
-
-    if not upscaled_path.exists():
-        raise HTTPException(status_code=404, detail="No upscaled video available")
-
-    file_mtime = int(upscaled_path.stat().st_mtime)
-    actual_filename = f"{job.get('name', 'video')}_upscaled_2x.mp4"
-
-    return FileResponse(
-        path=str(upscaled_path),
-        media_type="video/mp4",
-        filename=actual_filename,
-        headers={
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            "Pragma": "no-cache",
-            "Expires": "0",
-            "ETag": f'"{file_mtime}"'
-        }
-    )
-
-
 @router.get("/jobs/{job_id}/segments/{segment_index}/video")
 async def get_segment_video(job_id: int, segment_index: int):
     """Get the video for a specific segment.

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -227,10 +227,6 @@ class APIClient {
     return `${API_BASE_URL}/jobs/${jobId}/video`;
   }
 
-  getJobVideoUpscaled(jobId) {
-    return `${API_BASE_URL}/jobs/${jobId}/video/upscaled`;
-  }
-
   getSegmentVideo(jobId, segmentIndex) {
     return `${API_BASE_URL}/jobs/${jobId}/segments/${segmentIndex}/video`;
   }

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -72,7 +72,6 @@ export default function JobDetail() {
   const [elapsedTime, setElapsedTime] = useState(null);
   const [finalizing, setFinalizing] = useState(false);
   const [upscaling, setUpscaling] = useState(false);
-  const [hasUpscaled, setHasUpscaled] = useState(false);
   const [upscaledVideos, setUpscaledVideos] = useState([]);
   const autoFinalizeTriggeredRef = useRef(false);
 
@@ -274,19 +273,8 @@ export default function JobDetail() {
       const segmentWithoutPrompt = segmentsData.find(s => !s.prompt && s.status === 'pending');
       setNextSegmentIndex(segmentWithoutPrompt ? segmentWithoutPrompt.segment_index : segmentsData.length);
 
-      // Check if legacy upscaled video exists and load new upscaled videos list
+      // Load upscaled videos list
       if (jobData.status === 'completed') {
-        try {
-          const response = await fetch(API.getJobVideoUpscaled(id), {
-            method: 'GET',
-            headers: { 'Range': 'bytes=0-0' }
-          });
-          setHasUpscaled(response.ok || response.status === 206);
-        } catch {
-          setHasUpscaled(false);
-        }
-
-        // Load upscaled videos list
         try {
           const upscaledData = await API.getUpscaledVideos(id);
           setUpscaledVideos(upscaledData.videos || []);


### PR DESCRIPTION
The /api/jobs/{job_id}/video/upscaled endpoint was looking for a hardcoded file pattern in the job output directory, but upscaled videos are now stored in UPSCALE_SAVE_PATH with database tracking.

- Remove unused hasUpscaled state from JobDetail.jsx
- Remove legacy upscaled check (caused 404 spam in logs)
- Remove getJobVideoUpscaled method from client.js
- Remove /jobs/{job_id}/video/upscaled endpoint from routes.py

The working /api/jobs/{job_id}/upscaled-videos endpoint handles everything.

Fixes #170