### PR TITLE
Rework Settings page to two-column grid layout (#174)

### DIFF
--- a/react-app/src/pages/Settings.css
+++ b/react-app/src/pages/Settings.css
@@ -1,5 +1,17 @@
+.settings-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+}
+
+@media (max-width: 768px) {
+  .settings-container {
+    grid-template-columns: 1fr;
+  }
+}
+
 .settings-section {
-  margin-bottom: 24px;
+  margin-bottom: 0;
 }
 
 .settings-section h2 {

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -193,6 +193,7 @@ export default function Settings() {
       <h1>Settings</h1>
 
       <form onSubmit={handleSave}>
+        <div className="settings-container">
         {/* ComfyUI Configuration */}
         <div className="card settings-section">
           <h2>ComfyUI Configuration</h2>
@@ -468,6 +469,7 @@ export default function Settings() {
               This text is automatically prepended to all prompts (job creation and segment prompts)
             </small>
           </div>
+        </div>
         </div>
 
         {/* Save Button */}


### PR DESCRIPTION
- Add settings-container wrapper with CSS grid (2 columns)
- Responsive breakpoint at 768px collapses to single column
- Consistent 24px gap between sections
- Internal section styling preserved