### PR TITLE
Enforce strict DATABASE_PATH configuration (#185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,22 +6,24 @@ A local web application for generating long-form videos using the Wan2.2 image-t
 
 **This application runs on 2070.zero (remote GPU box), NOT locally.**
 
-### Environment Variables
+### Environment Variables (STRICT - NO FALLBACKS)
 
-The following environment variables are set in `~/.bashrc` on 2070.zero and MUST be loaded by `start-api.sh`:
+The `DATABASE_PATH` environment variable is **required**. The API will refuse to start if:
+- `DATABASE_PATH` is not set, OR
+- The database file does not exist at the specified path
 
-- `DATABASE_PATH` - Path to the SQLite database file
+There are **no default fallbacks**. This is intentional to prevent silent misconfiguration.
 
-**NEVER remove the `source ~/.bashrc` line from `start-api.sh`.** This loads critical environment variables including the database path. Removing it will cause the app to use a wrong/empty database.
+On 2070.zero, `DATABASE_PATH` is set to: `/home/david/projects/wan22-data/database/queue.db`
 
 ### Start Scripts
 
-`start-api.sh` MUST contain:
+`start-api.sh` sets `DATABASE_PATH` explicitly:
 ```bash
-[ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
+export DATABASE_PATH="${DATABASE_PATH:-/home/david/projects/wan22-data/database/queue.db}"
 ```
 
-This line loads user environment variables before starting the backend.
+**NEVER add fallback defaults to `database.py`** - the strict validation prevents the app from silently using the wrong database.
 
 ## Tech Stack
 

--- a/backend/convert_mp4_to_webm.py
+++ b/backend/convert_mp4_to_webm.py
@@ -10,7 +10,13 @@ import subprocess
 import sqlite3
 from pathlib import Path
 
-DB_PATH = os.environ.get("DB_PATH", "comfyui_queue.db")
+DB_PATH = os.environ.get("DATABASE_PATH")
+if not DB_PATH:
+    print("FATAL: DATABASE_PATH environment variable is not set.")
+    exit(1)
+if not Path(DB_PATH).exists():
+    print(f"FATAL: Database file not found at path: {DB_PATH}")
+    exit(1)
 
 def convert_video(mp4_path: str) -> str | None:
     """Convert an MP4 to WebM, return new path or None on failure."""

--- a/backend/database.py
+++ b/backend/database.py
@@ -101,12 +101,20 @@ def parse_loras(db_value: Optional[str]) -> List[Dict[str, Any]]:
     # Fall back to treating as single filename (legacy format)
     return [{"file": db_value, "weight": 1.0}]
 
-# Use absolute path to avoid issues with current working directory
-# DATABASE_PATH can be overridden via environment variable
+# DATABASE_PATH must be set via environment variable - no fallback allowed
 import os
+import sys
 from pathlib import Path
-BACKEND_DIR = Path(__file__).resolve().parent
-DATABASE_PATH = os.environ.get("DATABASE_PATH", str(BACKEND_DIR / "comfyui_queue.db"))
+
+DATABASE_PATH = os.environ.get("DATABASE_PATH")
+
+if not DATABASE_PATH:
+    print("FATAL: DATABASE_PATH environment variable is not set. Cannot start API.", file=sys.stderr)
+    sys.exit(1)
+
+if not Path(DATABASE_PATH).exists():
+    print(f"FATAL: Database file not found at path: {DATABASE_PATH}. Cannot start API.", file=sys.stderr)
+    sys.exit(1)
 
 
 @contextmanager


### PR DESCRIPTION
Remove all hardcoded database path defaults. The API now refuses to start if:
- DATABASE_PATH environment variable is not set
- Database file does not exist at the specified path

This prevents silent misconfiguration where the app would use an empty/wrong database without any warning.

Updated files:
- database.py: Strict validation with clear error messages
- convert_mp4_to_webm.py: Use DATABASE_PATH consistently
- CLAUDE.md: Document strict requirements