### PR TITLE
Add VR 180 settings to Settings page (#191)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -553,7 +553,12 @@ def init_db():
             "default_width": "640",
             "default_height": "640",
             "auto_start_queue": "true",
-            "image_repo_path": ""
+            "image_repo_path": "",
+            # VR 180 stereo image generation settings
+            "vr_eye_separation": "0.03",
+            "vr_depth_strength": "1.0",
+            "vr_output_width": "4128",
+            "vr_output_height": "2208"
         }
 
         for key, value in default_settings.items():

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -29,6 +29,10 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
   const [generatingVR, setGeneratingVR] = useState(false);
   const [vrImages, setVrImages] = useState([]);
   const [loadingVRImages, setLoadingVRImages] = useState(false);
+  const [vrSettings, setVrSettings] = useState({
+    eyeSeparation: 0.03,
+    depthStrength: 1.0
+  });
 
   // Lock scroll on .main-content when modal is open
   useEffect(() => {
@@ -107,6 +111,23 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
     }
     loadVRImages();
   }, [image.path]);
+
+  // Load VR settings once
+  useEffect(() => {
+    async function loadVRSettings() {
+      try {
+        const data = await API.getSettings();
+        const s = data.settings || data;
+        setVrSettings({
+          eyeSeparation: parseFloat(s.vr_eye_separation) || 0.03,
+          depthStrength: parseFloat(s.vr_depth_strength) || 1.0
+        });
+      } catch (error) {
+        console.error('Failed to load VR settings:', error);
+      }
+    }
+    loadVRSettings();
+  }, []);
 
   async function handleAddTag(tagName) {
     if (!tagName) return;
@@ -225,7 +246,11 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
     showToast('Starting VR image generation...', 'info');
 
     try {
-      const result = await API.generateVRImage(image.path);
+      const result = await API.generateVRImage(
+        image.path,
+        vrSettings.eyeSeparation,
+        vrSettings.depthStrength
+      );
       const vrId = result.vr_id;
 
       // Poll for completion

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -29,6 +29,13 @@ export default function Settings() {
   const [newDescription, setNewDescription] = useState('');
   const [promptIdentity, setPromptIdentity] = useState('');
   const [slideshowDelay, setSlideshowDelay] = useState(5);
+
+  // VR 180 stereo settings
+  const [vrEyeSeparation, setVrEyeSeparation] = useState(0.03);
+  const [vrDepthStrength, setVrDepthStrength] = useState(1.0);
+  const [vrOutputWidth, setVrOutputWidth] = useState(4128);
+  const [vrOutputHeight, setVrOutputHeight] = useState(2208);
+
   useEffect(() => {
     loadSettings();
     loadHiddenLoras();
@@ -63,6 +70,12 @@ export default function Settings() {
 
       setPromptIdentity(s.prompt_identity || '');
       setSlideshowDelay(parseInt(s.slideshow_delay) || 5);
+
+      // VR settings
+      setVrEyeSeparation(parseFloat(s.vr_eye_separation) || 0.03);
+      setVrDepthStrength(parseFloat(s.vr_depth_strength) || 1.0);
+      setVrOutputWidth(parseInt(s.vr_output_width) || 4128);
+      setVrOutputHeight(parseInt(s.vr_output_height) || 2208);
 
       setLoading(false);
     } catch (error) {
@@ -136,7 +149,12 @@ export default function Settings() {
         job_name_prefixes: JSON.stringify(namePrefixes),
         job_name_descriptions: JSON.stringify(nameDescriptions),
         prompt_identity: promptIdentity,
-        slideshow_delay: String(slideshowDelay)
+        slideshow_delay: String(slideshowDelay),
+        // VR settings
+        vr_eye_separation: String(vrEyeSeparation),
+        vr_depth_strength: String(vrDepthStrength),
+        vr_output_width: String(vrOutputWidth),
+        vr_output_height: String(vrOutputHeight)
       };
 
       await API.updateSettings(settingsPayload);
@@ -505,6 +523,73 @@ export default function Settings() {
             <small style={{ color: '#666', fontSize: '12px' }}>
               This text is automatically prepended to all prompts (job creation and segment prompts)
             </small>
+          </div>
+        </div>
+
+        {/* VR 180 Stereo Settings */}
+        <div className="card settings-section">
+          <h2>VR 180 Stereo</h2>
+          <p style={{ color: '#666', fontSize: '14px', marginBottom: '16px' }}>
+            Settings for generating VR 180° stereoscopic images using MiDaS depth estimation.
+            Optimized for Meta Quest 3S.
+          </p>
+          <div className="settings-grid">
+            <div className="form-group">
+              <label>Eye Separation</label>
+              <input
+                type="number"
+                value={vrEyeSeparation}
+                onChange={(e) => setVrEyeSeparation(parseFloat(e.target.value) || 0.03)}
+                min="0.01"
+                max="0.1"
+                step="0.005"
+              />
+              <small style={{ color: '#666', fontSize: '12px' }}>
+                Horizontal displacement factor (0.01-0.1). Higher = more 3D depth.
+              </small>
+            </div>
+            <div className="form-group">
+              <label>Depth Strength</label>
+              <input
+                type="number"
+                value={vrDepthStrength}
+                onChange={(e) => setVrDepthStrength(parseFloat(e.target.value) || 1.0)}
+                min="0.1"
+                max="3.0"
+                step="0.1"
+              />
+              <small style={{ color: '#666', fontSize: '12px' }}>
+                Multiplier for depth-based displacement (0.1-3.0).
+              </small>
+            </div>
+            <div className="form-group">
+              <label>Output Width</label>
+              <input
+                type="number"
+                value={vrOutputWidth}
+                onChange={(e) => setVrOutputWidth(parseInt(e.target.value) || 4128)}
+                min="1920"
+                max="8192"
+                step="8"
+              />
+              <small style={{ color: '#666', fontSize: '12px' }}>
+                Width of each eye view (total width = 2x). Default 4128 for Quest 3S.
+              </small>
+            </div>
+            <div className="form-group">
+              <label>Output Height</label>
+              <input
+                type="number"
+                value={vrOutputHeight}
+                onChange={(e) => setVrOutputHeight(parseInt(e.target.value) || 2208)}
+                min="1080"
+                max="4096"
+                step="8"
+              />
+              <small style={{ color: '#666', fontSize: '12px' }}>
+                Height of output image. Default 2208 for Quest 3S.
+              </small>
+            </div>
           </div>
         </div>
         </div>


### PR DESCRIPTION
- Add VR settings to database defaults (eye_separation, depth_strength, output_width, output_height)
- Add VR 180 Stereo section to Settings page with configurable parameters:
  - Eye Separation (0.01-0.1)
  - Depth Strength (0.1-3.0)
  - Output Width/Height (optimized for Quest 3S: 4128x2208)
- Update ImagePreviewModal to load and use VR settings when generating