### PR TITLE
Add equirectangular projection to VR stereo generator

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -558,7 +558,8 @@ def init_db():
             "vr_eye_separation": "0.03",
             "vr_depth_strength": "1.0",
             "vr_output_width": "4128",
-            "vr_output_height": "2208"
+            "vr_output_height": "2208",
+            "vr_equirectangular": "true"
         }
 
         for key, value in default_settings.items():

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2520,12 +2520,19 @@ async def generate_vr_image(
     background_tasks: BackgroundTasks,
     image_path: str = Form(...),
     eye_separation: float = Form(0.03),
-    depth_strength: float = Form(1.0)
+    depth_strength: float = Form(1.0),
+    equirectangular: bool = Form(True)
 ):
     """Start VR 180 stereo image generation for a source image.
 
     This is an async operation - returns immediately with a VR image ID
     that can be polled for status.
+
+    Args:
+        image_path: Path to source image relative to image repository
+        eye_separation: Horizontal displacement factor (0.01-0.1)
+        depth_strength: Multiplier for depth-based displacement (0.1-3.0)
+        equirectangular: Apply equirectangular projection for VR 180 display (default True)
     """
     from database import create_vr_image, update_vr_image_status
     from vr_stereo import generate_stereo_pair, get_vr_output_path, VR_OUTPUT_PATH as VR_PATH
@@ -2559,7 +2566,8 @@ async def generate_vr_image(
                 full_source_path,
                 output_path,
                 eye_separation=eye_separation,
-                depth_strength=depth_strength
+                depth_strength=depth_strength,
+                equirectangular=equirectangular
             )
             if success:
                 update_vr_image_status(vr_id, "completed", output_path=output_path)

--- a/backend/vr_stereo.py
+++ b/backend/vr_stereo.py
@@ -82,6 +82,65 @@ def unload_midas_model():
     print("[VRStereo] MiDaS model unloaded, GPU memory freed")
 
 
+def apply_equirectangular_projection(image: np.ndarray, fov_degrees: float = 180.0) -> np.ndarray:
+    """Apply equirectangular projection to a flat/rectilinear image.
+
+    This pre-warps the image so it displays correctly when mapped to a
+    hemispherical VR display using 180° SBS mode.
+
+    Args:
+        image: Input image (BGR format from OpenCV)
+        fov_degrees: Field of view in degrees (default 180 for VR 180)
+
+    Returns:
+        Equirectangular projected image
+    """
+    import cv2
+
+    height, width = image.shape[:2]
+    fov_rad = np.radians(fov_degrees)
+
+    # Create output coordinate grids
+    # For equirectangular, x maps to longitude (-pi/2 to pi/2 for 180°)
+    # and y maps to latitude (-pi/4 to pi/4 for typical aspect ratio)
+    u = np.linspace(-0.5, 0.5, width).astype(np.float32)
+    v = np.linspace(-0.5, 0.5, height).astype(np.float32)
+    u_grid, v_grid = np.meshgrid(u, v)
+
+    # Convert normalized coordinates to spherical angles
+    # longitude (theta) spans the horizontal FOV
+    # latitude (phi) spans the vertical FOV (adjusted for aspect ratio)
+    theta = u_grid * fov_rad  # -pi/2 to pi/2 for 180°
+    phi = v_grid * fov_rad * (height / width)  # Maintain aspect ratio
+
+    # Convert spherical to 3D Cartesian (on unit sphere)
+    x = np.cos(phi) * np.sin(theta)
+    y = np.sin(phi)
+    z = np.cos(phi) * np.cos(theta)
+
+    # Project back to flat image coordinates (rectilinear projection)
+    # This gives us where to sample from the original image
+    # Using gnomonic (rectilinear) projection formula
+    src_x = x / (z + 1e-10)  # Avoid division by zero
+    src_y = y / (z + 1e-10)
+
+    # Normalize to image coordinates
+    # The source image is assumed to have a certain FOV that we're mapping from
+    # Scale factor based on how much the image should be "zoomed"
+    scale = 0.8  # Adjustable - controls how much of the source is used
+    map_x = ((src_x * scale + 0.5) * width).astype(np.float32)
+    map_y = ((src_y * scale + 0.5) * height).astype(np.float32)
+
+    # Clip to valid range
+    map_x = np.clip(map_x, 0, width - 1)
+    map_y = np.clip(map_y, 0, height - 1)
+
+    # Remap the image
+    result = cv2.remap(image, map_x, map_y, cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT)
+
+    return result
+
+
 def estimate_depth(image_path: str) -> np.ndarray:
     """Estimate depth map from an image using MiDaS.
 
@@ -123,7 +182,8 @@ def generate_stereo_pair(
     image_path: str,
     output_path: str,
     eye_separation: float = 0.03,
-    depth_strength: float = 1.0
+    depth_strength: float = 1.0,
+    equirectangular: bool = True
 ) -> Tuple[bool, str]:
     """Generate a VR 180 stereo image from a single image.
 
@@ -132,6 +192,7 @@ def generate_stereo_pair(
         output_path: Path for the output stereo image
         eye_separation: Horizontal displacement factor (default 0.03 = 3% of image width)
         depth_strength: Multiplier for depth-based displacement (default 1.0)
+        equirectangular: Apply equirectangular projection for proper VR 180 display (default True)
 
     Returns:
         Tuple of (success, message)
@@ -184,6 +245,12 @@ def generate_stereo_pair(
             left_eye = cv2.inpaint(left_eye, left_mask, 3, cv2.INPAINT_TELEA)
         if np.any(right_mask):
             right_eye = cv2.inpaint(right_eye, right_mask, 3, cv2.INPAINT_TELEA)
+
+        # Apply equirectangular projection for proper VR 180 display
+        if equirectangular:
+            print("[VRStereo] Applying equirectangular projection...")
+            left_eye = apply_equirectangular_projection(left_eye)
+            right_eye = apply_equirectangular_projection(right_eye)
 
         # Create side-by-side stereo image (left | right)
         stereo = np.hstack([left_eye, right_eye])

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -546,11 +546,12 @@ class APIClient {
 
   // ============== VR 180 Stereo Images ==============
 
-  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0) {
+  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0, equirectangular = true) {
     const formData = new FormData();
     formData.append('image_path', imagePath);
     formData.append('eye_separation', eyeSeparation.toString());
     formData.append('depth_strength', depthStrength.toString());
+    formData.append('equirectangular', equirectangular.toString());
 
     return this.request('/vr/generate', {
       method: 'POST',

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -31,7 +31,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
   const [loadingVRImages, setLoadingVRImages] = useState(false);
   const [vrSettings, setVrSettings] = useState({
     eyeSeparation: 0.03,
-    depthStrength: 1.0
+    depthStrength: 1.0,
+    equirectangular: true
   });
 
   // Lock scroll on .main-content when modal is open
@@ -120,7 +121,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         const s = data.settings || data;
         setVrSettings({
           eyeSeparation: parseFloat(s.vr_eye_separation) || 0.03,
-          depthStrength: parseFloat(s.vr_depth_strength) || 1.0
+          depthStrength: parseFloat(s.vr_depth_strength) || 1.0,
+          equirectangular: s.vr_equirectangular !== 'false'
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -249,7 +251,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
       const result = await API.generateVRImage(
         image.path,
         vrSettings.eyeSeparation,
-        vrSettings.depthStrength
+        vrSettings.depthStrength,
+        vrSettings.equirectangular
       );
       const vrId = result.vr_id;
 

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -35,6 +35,7 @@ export default function Settings() {
   const [vrDepthStrength, setVrDepthStrength] = useState(1.0);
   const [vrOutputWidth, setVrOutputWidth] = useState(4128);
   const [vrOutputHeight, setVrOutputHeight] = useState(2208);
+  const [vrEquirectangular, setVrEquirectangular] = useState(true);
 
   useEffect(() => {
     loadSettings();
@@ -76,6 +77,7 @@ export default function Settings() {
       setVrDepthStrength(parseFloat(s.vr_depth_strength) || 1.0);
       setVrOutputWidth(parseInt(s.vr_output_width) || 4128);
       setVrOutputHeight(parseInt(s.vr_output_height) || 2208);
+      setVrEquirectangular(s.vr_equirectangular !== 'false');
 
       setLoading(false);
     } catch (error) {
@@ -154,7 +156,8 @@ export default function Settings() {
         vr_eye_separation: String(vrEyeSeparation),
         vr_depth_strength: String(vrDepthStrength),
         vr_output_width: String(vrOutputWidth),
-        vr_output_height: String(vrOutputHeight)
+        vr_output_height: String(vrOutputHeight),
+        vr_equirectangular: String(vrEquirectangular)
       };
 
       await API.updateSettings(settingsPayload);
@@ -590,6 +593,20 @@ export default function Settings() {
                 Height of output image. Default 2208 for Quest 3S.
               </small>
             </div>
+          </div>
+          <div className="form-group" style={{ marginTop: '16px' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={vrEquirectangular}
+                onChange={(e) => setVrEquirectangular(e.target.checked)}
+                style={{ width: 'auto', margin: 0 }}
+              />
+              Equirectangular Projection
+            </label>
+            <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+              Apply equirectangular projection for proper VR 180° viewing. Enable for VR headsets (Quest, etc.), disable for flat SBS viewing.
+            </small>
           </div>
         </div>
         </div>


### PR DESCRIPTION
- Add apply_equirectangular_projection() function for proper VR 180 display
- Add equirectangular parameter to generate_stereo_pair() (default True)
- Add vr_equirectangular setting to database defaults
- Wire setting through /vr/generate API endpoint
- Add toggle checkbox in Settings page (VR 180 Stereo section)
- Update API client to pass equirectangular parameter
- Update ImagePreviewModal to load and use the setting

When enabled, pre-warps images so they display correctly when mapped to a hemispherical VR display in 180° SBS mode.

Fixes #196