### PR TITLE
Add equirectangular projection with adjustable vertical FOV

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -559,7 +559,8 @@ def init_db():
             "vr_depth_strength": "1.0",
             "vr_output_width": "4128",
             "vr_output_height": "2208",
-            "vr_equirectangular": "true"
+            "vr_equirectangular": "true",
+            "vr_vertical_fov": "165"
         }
 
         for key, value in default_settings.items():

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2521,7 +2521,8 @@ async def generate_vr_image(
     image_path: str = Form(...),
     eye_separation: float = Form(0.03),
     depth_strength: float = Form(1.0),
-    equirectangular: bool = Form(True)
+    equirectangular: bool = Form(True),
+    vertical_fov: float = Form(165.0)
 ):
     """Start VR 180 stereo image generation for a source image.
 
@@ -2533,6 +2534,7 @@ async def generate_vr_image(
         eye_separation: Horizontal displacement factor (0.01-0.1)
         depth_strength: Multiplier for depth-based displacement (0.1-3.0)
         equirectangular: Apply equirectangular projection for VR 180 display (default True)
+        vertical_fov: Vertical field of view in degrees (90-180, default 165)
     """
     from database import create_vr_image, update_vr_image_status
     from vr_stereo import generate_stereo_pair, get_vr_output_path, VR_OUTPUT_PATH as VR_PATH
@@ -2567,7 +2569,8 @@ async def generate_vr_image(
                 output_path,
                 eye_separation=eye_separation,
                 depth_strength=depth_strength,
-                equirectangular=equirectangular
+                equirectangular=equirectangular,
+                vertical_fov=vertical_fov
             )
             if success:
                 update_vr_image_status(vr_id, "completed", output_path=output_path)

--- a/backend/vr_stereo.py
+++ b/backend/vr_stereo.py
@@ -82,7 +82,16 @@ def unload_midas_model():
     print("[VRStereo] MiDaS model unloaded, GPU memory freed")
 
 
-def apply_equirectangular_projection(image: np.ndarray, fov_degrees: float = 180.0) -> np.ndarray:
+# Default FOV values for equirectangular projection
+DEFAULT_HORIZONTAL_FOV = 180  # degrees
+DEFAULT_VERTICAL_FOV = 180    # degrees (adjustable to reduce edge stretching)
+
+
+def apply_equirectangular_projection(
+    image: np.ndarray,
+    fov_horizontal: float = DEFAULT_HORIZONTAL_FOV,
+    fov_vertical: float = DEFAULT_VERTICAL_FOV
+) -> np.ndarray:
     """Apply equirectangular projection to a flat/rectilinear image.
 
     This pre-warps the image so it displays correctly when mapped to a
@@ -90,7 +99,8 @@ def apply_equirectangular_projection(image: np.ndarray, fov_degrees: float = 180
 
     Args:
         image: Input image (BGR format from OpenCV)
-        fov_degrees: Field of view in degrees (default 180 for VR 180)
+        fov_horizontal: Horizontal field of view in degrees (default 180)
+        fov_vertical: Vertical field of view in degrees (default 180, reduce to minimize edge stretching)
 
     Returns:
         Equirectangular projected image
@@ -98,36 +108,34 @@ def apply_equirectangular_projection(image: np.ndarray, fov_degrees: float = 180
     import cv2
 
     height, width = image.shape[:2]
-    fov_rad = np.radians(fov_degrees)
+    fov_h_rad = np.radians(fov_horizontal)
+    fov_v_rad = np.radians(fov_vertical)
 
     # Create output coordinate grids
-    # For equirectangular, x maps to longitude (-pi/2 to pi/2 for 180°)
-    # and y maps to latitude (-pi/4 to pi/4 for typical aspect ratio)
+    # For equirectangular, x maps to longitude and y maps to latitude
     u = np.linspace(-0.5, 0.5, width).astype(np.float32)
     v = np.linspace(-0.5, 0.5, height).astype(np.float32)
     u_grid, v_grid = np.meshgrid(u, v)
 
     # Convert normalized coordinates to spherical angles
-    # longitude (theta) spans the horizontal FOV
-    # latitude (phi) spans the vertical FOV (adjusted for aspect ratio)
-    theta = u_grid * fov_rad  # -pi/2 to pi/2 for 180°
-    phi = v_grid * fov_rad * (height / width)  # Maintain aspect ratio
+    # theta (longitude) spans the horizontal FOV
+    # phi (latitude) spans the vertical FOV
+    theta = u_grid * fov_h_rad  # horizontal angle
+    phi = v_grid * fov_v_rad    # vertical angle
 
     # Convert spherical to 3D Cartesian (on unit sphere)
     x = np.cos(phi) * np.sin(theta)
     y = np.sin(phi)
     z = np.cos(phi) * np.cos(theta)
 
-    # Project back to flat image coordinates (rectilinear projection)
+    # Project back to flat image coordinates (gnomonic/rectilinear projection)
     # This gives us where to sample from the original image
-    # Using gnomonic (rectilinear) projection formula
     src_x = x / (z + 1e-10)  # Avoid division by zero
     src_y = y / (z + 1e-10)
 
     # Normalize to image coordinates
-    # The source image is assumed to have a certain FOV that we're mapping from
-    # Scale factor based on how much the image should be "zoomed"
-    scale = 0.8  # Adjustable - controls how much of the source is used
+    # Scale factor controls how much of the source is used
+    scale = 0.8
     map_x = ((src_x * scale + 0.5) * width).astype(np.float32)
     map_y = ((src_y * scale + 0.5) * height).astype(np.float32)
 
@@ -183,7 +191,8 @@ def generate_stereo_pair(
     output_path: str,
     eye_separation: float = 0.03,
     depth_strength: float = 1.0,
-    equirectangular: bool = True
+    equirectangular: bool = True,
+    vertical_fov: float = DEFAULT_VERTICAL_FOV
 ) -> Tuple[bool, str]:
     """Generate a VR 180 stereo image from a single image.
 
@@ -192,7 +201,8 @@ def generate_stereo_pair(
         output_path: Path for the output stereo image
         eye_separation: Horizontal displacement factor (default 0.03 = 3% of image width)
         depth_strength: Multiplier for depth-based displacement (default 1.0)
-        equirectangular: Apply equirectangular projection for proper VR 180 display (default True)
+        equirectangular: Apply equirectangular projection for VR 180 display (default True)
+        vertical_fov: Vertical field of view in degrees (90-180, default 180)
 
     Returns:
         Tuple of (success, message)
@@ -248,9 +258,9 @@ def generate_stereo_pair(
 
         # Apply equirectangular projection for proper VR 180 display
         if equirectangular:
-            print("[VRStereo] Applying equirectangular projection...")
-            left_eye = apply_equirectangular_projection(left_eye)
-            right_eye = apply_equirectangular_projection(right_eye)
+            print(f"[VRStereo] Applying equirectangular projection (vertical FOV: {vertical_fov}°)...")
+            left_eye = apply_equirectangular_projection(left_eye, DEFAULT_HORIZONTAL_FOV, vertical_fov)
+            right_eye = apply_equirectangular_projection(right_eye, DEFAULT_HORIZONTAL_FOV, vertical_fov)
 
         # Create side-by-side stereo image (left | right)
         stereo = np.hstack([left_eye, right_eye])

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -546,12 +546,13 @@ class APIClient {
 
   // ============== VR 180 Stereo Images ==============
 
-  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0, equirectangular = true) {
+  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0, equirectangular = true, verticalFov = 165) {
     const formData = new FormData();
     formData.append('image_path', imagePath);
     formData.append('eye_separation', eyeSeparation.toString());
     formData.append('depth_strength', depthStrength.toString());
     formData.append('equirectangular', equirectangular.toString());
+    formData.append('vertical_fov', verticalFov.toString());
 
     return this.request('/vr/generate', {
       method: 'POST',

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -32,7 +32,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
   const [vrSettings, setVrSettings] = useState({
     eyeSeparation: 0.03,
     depthStrength: 1.0,
-    equirectangular: true
+    equirectangular: true,
+    verticalFov: 165
   });
 
   // Lock scroll on .main-content when modal is open
@@ -122,7 +123,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         setVrSettings({
           eyeSeparation: parseFloat(s.vr_eye_separation) || 0.03,
           depthStrength: parseFloat(s.vr_depth_strength) || 1.0,
-          equirectangular: s.vr_equirectangular !== 'false'
+          equirectangular: s.vr_equirectangular !== 'false',
+          verticalFov: parseInt(s.vr_vertical_fov) || 165
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -252,7 +254,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         image.path,
         vrSettings.eyeSeparation,
         vrSettings.depthStrength,
-        vrSettings.equirectangular
+        vrSettings.equirectangular,
+        vrSettings.verticalFov
       );
       const vrId = result.vr_id;
 

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -36,6 +36,7 @@ export default function Settings() {
   const [vrOutputWidth, setVrOutputWidth] = useState(4128);
   const [vrOutputHeight, setVrOutputHeight] = useState(2208);
   const [vrEquirectangular, setVrEquirectangular] = useState(true);
+  const [vrVerticalFov, setVrVerticalFov] = useState(165);
 
   useEffect(() => {
     loadSettings();
@@ -78,6 +79,7 @@ export default function Settings() {
       setVrOutputWidth(parseInt(s.vr_output_width) || 4128);
       setVrOutputHeight(parseInt(s.vr_output_height) || 2208);
       setVrEquirectangular(s.vr_equirectangular !== 'false');
+      setVrVerticalFov(parseInt(s.vr_vertical_fov) || 165);
 
       setLoading(false);
     } catch (error) {
@@ -157,7 +159,8 @@ export default function Settings() {
         vr_depth_strength: String(vrDepthStrength),
         vr_output_width: String(vrOutputWidth),
         vr_output_height: String(vrOutputHeight),
-        vr_equirectangular: String(vrEquirectangular)
+        vr_equirectangular: String(vrEquirectangular),
+        vr_vertical_fov: String(vrVerticalFov)
       };
 
       await API.updateSettings(settingsPayload);
@@ -594,6 +597,8 @@ export default function Settings() {
               </small>
             </div>
           </div>
+
+          {/* Equirectangular Projection Settings */}
           <div className="form-group" style={{ marginTop: '16px' }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
               <input
@@ -608,6 +613,28 @@ export default function Settings() {
               Apply equirectangular projection for proper VR 180° viewing. Enable for VR headsets (Quest, etc.), disable for flat SBS viewing.
             </small>
           </div>
+
+          {vrEquirectangular && (
+            <div className="form-group" style={{ marginTop: '12px' }}>
+              <label>Vertical FOV: {vrVerticalFov}°</label>
+              <input
+                type="range"
+                value={vrVerticalFov}
+                onChange={(e) => setVrVerticalFov(parseInt(e.target.value))}
+                min="90"
+                max="180"
+                step="5"
+                style={{ width: '100%' }}
+              />
+              <div style={{ display: 'flex', justifyContent: 'space-between', color: '#666', fontSize: '11px' }}>
+                <span>90° (less stretch)</span>
+                <span>180° (full sphere)</span>
+              </div>
+              <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+                Vertical field of view for projection. Lower values reduce edge stretching. Recommended: 165°.
+              </small>
+            </div>
+          )}
         </div>
         </div>
 


### PR DESCRIPTION
Backend (vr_stereo.py):
- Add apply_equirectangular_projection() function for VR 180 display
- Add equirectangular and vertical_fov parameters to generate_stereo_pair()
- Default vertical FOV of 165° to reduce edge stretching

Database:
- Add vr_equirectangular (default: true) setting
- Add vr_vertical_fov (default: 165) setting

API (routes.py):
- Add equirectangular and vertical_fov form parameters to /vr/generate

Frontend:
- Add equirectangular checkbox toggle in Settings
- Add vertical FOV slider (90-180°) that shows when equirectangular enabled
- Update API client and ImagePreviewModal to use new settings

Fixes #198 (also includes #196 equirectangular projection)