### PR TITLE
Add depth smoothing and output sharpening to VR stereo generator

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -560,7 +560,9 @@ def init_db():
             "vr_output_width": "4128",
             "vr_output_height": "2208",
             "vr_equirectangular": "true",
-            "vr_vertical_fov": "165"
+            "vr_vertical_fov": "165",
+            "vr_depth_smoothing": "2.0",
+            "vr_output_sharpening": "0.3"
         }
 
         for key, value in default_settings.items():

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2522,7 +2522,9 @@ async def generate_vr_image(
     eye_separation: float = Form(0.03),
     depth_strength: float = Form(1.0),
     equirectangular: bool = Form(True),
-    vertical_fov: float = Form(165.0)
+    vertical_fov: float = Form(165.0),
+    depth_smoothing: float = Form(2.0),
+    output_sharpening: float = Form(0.3)
 ):
     """Start VR 180 stereo image generation for a source image.
 
@@ -2535,6 +2537,8 @@ async def generate_vr_image(
         depth_strength: Multiplier for depth-based displacement (0.1-3.0)
         equirectangular: Apply equirectangular projection for VR 180 display (default True)
         vertical_fov: Vertical field of view in degrees (90-180, default 165)
+        depth_smoothing: Gaussian blur sigma for depth map (0 = disabled, default 2.0)
+        output_sharpening: Unsharp mask strength for final output (0 = disabled, default 0.3)
     """
     from database import create_vr_image, update_vr_image_status
     from vr_stereo import generate_stereo_pair, get_vr_output_path, VR_OUTPUT_PATH as VR_PATH
@@ -2570,7 +2574,9 @@ async def generate_vr_image(
                 eye_separation=eye_separation,
                 depth_strength=depth_strength,
                 equirectangular=equirectangular,
-                vertical_fov=vertical_fov
+                vertical_fov=vertical_fov,
+                depth_smoothing=depth_smoothing,
+                output_sharpening=output_sharpening
             )
             if success:
                 update_vr_image_status(vr_id, "completed", output_path=output_path)

--- a/backend/vr_stereo.py
+++ b/backend/vr_stereo.py
@@ -86,6 +86,51 @@ def unload_midas_model():
 DEFAULT_HORIZONTAL_FOV = 180  # degrees
 DEFAULT_VERTICAL_FOV = 180    # degrees (adjustable to reduce edge stretching)
 
+# Quality enhancement defaults
+DEFAULT_DEPTH_SMOOTHING = 2.0   # Gaussian blur sigma for depth map (0 = disabled)
+DEFAULT_OUTPUT_SHARPENING = 0.3  # Unsharp mask strength (0 = disabled, max ~1.0)
+
+
+def smooth_depth_map(depth: np.ndarray, sigma: float = DEFAULT_DEPTH_SMOOTHING) -> np.ndarray:
+    """Apply Gaussian blur to depth map to smooth harsh stereo transitions.
+
+    Args:
+        depth: Depth map as numpy array (0-1 range)
+        sigma: Gaussian blur sigma (0 = no smoothing, higher = more blur)
+
+    Returns:
+        Smoothed depth map
+    """
+    if sigma <= 0:
+        return depth
+
+    from scipy.ndimage import gaussian_filter
+    return gaussian_filter(depth, sigma=sigma)
+
+
+def apply_sharpening(image: np.ndarray, strength: float = DEFAULT_OUTPUT_SHARPENING) -> np.ndarray:
+    """Apply unsharp mask to restore crispness lost during remapping.
+
+    Args:
+        image: Input image (BGR format from OpenCV)
+        strength: Sharpening strength (0 = disabled, 0.3 = moderate, 1.0 = strong)
+
+    Returns:
+        Sharpened image
+    """
+    if strength <= 0:
+        return image
+
+    import cv2
+
+    # Create blurred version for unsharp mask
+    blurred = cv2.GaussianBlur(image, (0, 0), sigmaX=3)
+
+    # Unsharp mask: sharpened = original + strength * (original - blurred)
+    sharpened = cv2.addWeighted(image, 1.0 + strength, blurred, -strength, 0)
+
+    return sharpened
+
 
 def apply_equirectangular_projection(
     image: np.ndarray,
@@ -194,7 +239,9 @@ def generate_stereo_pair(
     eye_separation: float = 0.03,
     depth_strength: float = 1.0,
     equirectangular: bool = True,
-    vertical_fov: float = DEFAULT_VERTICAL_FOV
+    vertical_fov: float = DEFAULT_VERTICAL_FOV,
+    depth_smoothing: float = DEFAULT_DEPTH_SMOOTHING,
+    output_sharpening: float = DEFAULT_OUTPUT_SHARPENING
 ) -> Tuple[bool, str]:
     """Generate a VR 180 stereo image from a single image.
 
@@ -205,6 +252,8 @@ def generate_stereo_pair(
         depth_strength: Multiplier for depth-based displacement (default 1.0)
         equirectangular: Apply equirectangular projection for VR 180 display (default True)
         vertical_fov: Vertical field of view in degrees (90-180, default 180)
+        depth_smoothing: Gaussian blur sigma for depth map (0 = disabled, default 2.0)
+        output_sharpening: Unsharp mask strength for final output (0 = disabled, default 0.3)
 
     Returns:
         Tuple of (success, message)
@@ -227,6 +276,11 @@ def generate_stereo_pair(
         # Estimate depth
         print("[VRStereo] Estimating depth...")
         depth = estimate_depth(image_path)
+
+        # Apply depth smoothing to reduce harsh stereo transitions
+        if depth_smoothing > 0:
+            print(f"[VRStereo] Applying depth smoothing (sigma={depth_smoothing})...")
+            depth = smooth_depth_map(depth, depth_smoothing)
 
         # Calculate pixel displacement based on depth
         # Closer objects (higher depth) should have more displacement
@@ -266,6 +320,11 @@ def generate_stereo_pair(
 
         # Create side-by-side stereo image (left | right)
         stereo = np.hstack([left_eye, right_eye])
+
+        # Apply output sharpening to restore crispness
+        if output_sharpening > 0:
+            print(f"[VRStereo] Applying output sharpening (strength={output_sharpening})...")
+            stereo = apply_sharpening(stereo, output_sharpening)
 
         # Save the stereo image
         print(f"[VRStereo] Saving stereo image: {output_path}")

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -546,13 +546,15 @@ class APIClient {
 
   // ============== VR 180 Stereo Images ==============
 
-  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0, equirectangular = true, verticalFov = 165) {
+  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0, equirectangular = true, verticalFov = 165, depthSmoothing = 2.0, outputSharpening = 0.3) {
     const formData = new FormData();
     formData.append('image_path', imagePath);
     formData.append('eye_separation', eyeSeparation.toString());
     formData.append('depth_strength', depthStrength.toString());
     formData.append('equirectangular', equirectangular.toString());
     formData.append('vertical_fov', verticalFov.toString());
+    formData.append('depth_smoothing', depthSmoothing.toString());
+    formData.append('output_sharpening', outputSharpening.toString());
 
     return this.request('/vr/generate', {
       method: 'POST',

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -33,7 +33,9 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
     eyeSeparation: 0.03,
     depthStrength: 1.0,
     equirectangular: true,
-    verticalFov: 165
+    verticalFov: 165,
+    depthSmoothing: 2.0,
+    outputSharpening: 0.3
   });
 
   // Lock scroll on .main-content when modal is open
@@ -124,7 +126,9 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
           eyeSeparation: parseFloat(s.vr_eye_separation) || 0.03,
           depthStrength: parseFloat(s.vr_depth_strength) || 1.0,
           equirectangular: s.vr_equirectangular !== 'false',
-          verticalFov: parseInt(s.vr_vertical_fov) || 165
+          verticalFov: parseInt(s.vr_vertical_fov) || 165,
+          depthSmoothing: parseFloat(s.vr_depth_smoothing) || 2.0,
+          outputSharpening: parseFloat(s.vr_output_sharpening) || 0.3
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -255,7 +259,9 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         vrSettings.eyeSeparation,
         vrSettings.depthStrength,
         vrSettings.equirectangular,
-        vrSettings.verticalFov
+        vrSettings.verticalFov,
+        vrSettings.depthSmoothing,
+        vrSettings.outputSharpening
       );
       const vrId = result.vr_id;
 

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -37,6 +37,8 @@ export default function Settings() {
   const [vrOutputHeight, setVrOutputHeight] = useState(2208);
   const [vrEquirectangular, setVrEquirectangular] = useState(true);
   const [vrVerticalFov, setVrVerticalFov] = useState(165);
+  const [vrDepthSmoothing, setVrDepthSmoothing] = useState(2.0);
+  const [vrOutputSharpening, setVrOutputSharpening] = useState(0.3);
 
   useEffect(() => {
     loadSettings();
@@ -80,6 +82,8 @@ export default function Settings() {
       setVrOutputHeight(parseInt(s.vr_output_height) || 2208);
       setVrEquirectangular(s.vr_equirectangular !== 'false');
       setVrVerticalFov(parseInt(s.vr_vertical_fov) || 165);
+      setVrDepthSmoothing(parseFloat(s.vr_depth_smoothing) || 2.0);
+      setVrOutputSharpening(parseFloat(s.vr_output_sharpening) || 0.3);
 
       setLoading(false);
     } catch (error) {
@@ -160,7 +164,9 @@ export default function Settings() {
         vr_output_width: String(vrOutputWidth),
         vr_output_height: String(vrOutputHeight),
         vr_equirectangular: String(vrEquirectangular),
-        vr_vertical_fov: String(vrVerticalFov)
+        vr_vertical_fov: String(vrVerticalFov),
+        vr_depth_smoothing: String(vrDepthSmoothing),
+        vr_output_sharpening: String(vrOutputSharpening)
       };
 
       await API.updateSettings(settingsPayload);
@@ -635,6 +641,46 @@ export default function Settings() {
               </small>
             </div>
           )}
+
+          <div className="form-group" style={{ marginTop: '16px' }}>
+            <label>Depth Smoothing: {vrDepthSmoothing}</label>
+            <input
+              type="range"
+              value={vrDepthSmoothing}
+              onChange={(e) => setVrDepthSmoothing(parseFloat(e.target.value))}
+              min="0"
+              max="5"
+              step="0.5"
+              style={{ width: '100%' }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', color: '#666', fontSize: '11px' }}>
+              <span>0 (off)</span>
+              <span>5 (max blur)</span>
+            </div>
+            <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+              Gaussian blur applied to depth map to smooth harsh stereo transitions. Recommended: 2.0.
+            </small>
+          </div>
+
+          <div className="form-group" style={{ marginTop: '12px' }}>
+            <label>Output Sharpening: {vrOutputSharpening}</label>
+            <input
+              type="range"
+              value={vrOutputSharpening}
+              onChange={(e) => setVrOutputSharpening(parseFloat(e.target.value))}
+              min="0"
+              max="1"
+              step="0.1"
+              style={{ width: '100%' }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', color: '#666', fontSize: '11px' }}>
+              <span>0 (off)</span>
+              <span>1.0 (strong)</span>
+            </div>
+            <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+              Unsharp mask applied to final output to restore crispness. Recommended: 0.3.
+            </small>
+          </div>
         </div>
         </div>
 


### PR DESCRIPTION
- Add smooth_depth_map() using Gaussian blur to reduce harsh stereo transitions
- Add apply_sharpening() using unsharp mask to restore crispness after remapping
- Add vr_depth_smoothing (default 2.0) and vr_output_sharpening (default 0.3) settings
- Add UI sliders in Settings page for both new parameters
- Wire through routes.py and API client

Closes #205