### PR TITLE
VR Stereo Generator - Comprehensive fixes for Quest 3S

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -554,13 +554,13 @@ def init_db():
             "default_height": "640",
             "auto_start_queue": "true",
             "image_repo_path": "",
-            # VR 180 stereo image generation settings
-            "vr_eye_separation": "0.03",
-            "vr_depth_strength": "1.0",
+            # VR 180 stereo image generation settings (validated for Quest 3S)
+            "vr_eye_separation": "0.015",
+            "vr_depth_strength": "0.5",
             "vr_output_width": "4128",
             "vr_output_height": "2208",
-            "vr_equirectangular": "true",
-            "vr_vertical_fov": "165",
+            "vr_equirectangular": "false",
+            "vr_vertical_fov": "90",
             "vr_depth_smoothing": "2.0",
             "vr_output_sharpening": "0.3"
         }

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2519,12 +2519,14 @@ VR_OUTPUT_PATH = os.environ.get("VR_OUTPUT_PATH")
 async def generate_vr_image(
     background_tasks: BackgroundTasks,
     image_path: str = Form(...),
-    eye_separation: float = Form(0.03),
-    depth_strength: float = Form(1.0),
-    equirectangular: bool = Form(True),
-    vertical_fov: float = Form(165.0),
+    eye_separation: float = Form(0.015),
+    depth_strength: float = Form(0.5),
+    equirectangular: bool = Form(False),
+    vertical_fov: float = Form(90.0),
     depth_smoothing: float = Form(2.0),
-    output_sharpening: float = Form(0.3)
+    output_sharpening: float = Form(0.3),
+    output_width: int = Form(4128),
+    output_height: int = Form(2208)
 ):
     """Start VR 180 stereo image generation for a source image.
 
@@ -2533,12 +2535,14 @@ async def generate_vr_image(
 
     Args:
         image_path: Path to source image relative to image repository
-        eye_separation: Horizontal displacement factor (0.01-0.1)
-        depth_strength: Multiplier for depth-based displacement (0.1-3.0)
-        equirectangular: Apply equirectangular projection for VR 180 display (default True)
-        vertical_fov: Vertical field of view in degrees (90-180, default 165)
+        eye_separation: Horizontal displacement factor (default 0.015 for Quest 3S)
+        depth_strength: Multiplier for depth-based displacement (default 0.5)
+        equirectangular: Apply equirectangular projection (default False at 90° FOV)
+        vertical_fov: Vertical field of view in degrees (default 90)
         depth_smoothing: Gaussian blur sigma for depth map (0 = disabled, default 2.0)
         output_sharpening: Unsharp mask strength for final output (0 = disabled, default 0.3)
+        output_width: Final stereo image width (default 4128 for Quest 3S)
+        output_height: Final stereo image height (default 2208 for Quest 3S)
     """
     from database import create_vr_image, update_vr_image_status
     from vr_stereo import generate_stereo_pair, get_vr_output_path, VR_OUTPUT_PATH as VR_PATH
@@ -2576,7 +2580,9 @@ async def generate_vr_image(
                 equirectangular=equirectangular,
                 vertical_fov=vertical_fov,
                 depth_smoothing=depth_smoothing,
-                output_sharpening=output_sharpening
+                output_sharpening=output_sharpening,
+                output_width=output_width,
+                output_height=output_height
             )
             if success:
                 update_vr_image_status(vr_id, "completed", output_path=output_path)

--- a/backend/vr_stereo.py
+++ b/backend/vr_stereo.py
@@ -84,7 +84,14 @@ def unload_midas_model():
 
 # Default FOV values for equirectangular projection
 DEFAULT_HORIZONTAL_FOV = 180  # degrees
-DEFAULT_VERTICAL_FOV = 180    # degrees (adjustable to reduce edge stretching)
+DEFAULT_VERTICAL_FOV = 90     # degrees (90 = no projection correction needed)
+
+# Validated Quest 3S defaults
+DEFAULT_EYE_SEPARATION = 0.015   # Reduced from 0.03 to minimize eye strain
+DEFAULT_DEPTH_STRENGTH = 0.5     # Moderate 3D effect
+DEFAULT_EQUIRECTANGULAR = False  # Disabled - unnecessary at 90° FOV
+DEFAULT_OUTPUT_WIDTH = 4128      # Quest 3S native width (per eye: 2064)
+DEFAULT_OUTPUT_HEIGHT = 2208     # Quest 3S native height
 
 # Quality enhancement defaults
 DEFAULT_DEPTH_SMOOTHING = 2.0   # Gaussian blur sigma for depth map (0 = disabled)
@@ -236,24 +243,28 @@ def estimate_depth(image_path: str) -> np.ndarray:
 def generate_stereo_pair(
     image_path: str,
     output_path: str,
-    eye_separation: float = 0.03,
-    depth_strength: float = 1.0,
-    equirectangular: bool = True,
+    eye_separation: float = DEFAULT_EYE_SEPARATION,
+    depth_strength: float = DEFAULT_DEPTH_STRENGTH,
+    equirectangular: bool = DEFAULT_EQUIRECTANGULAR,
     vertical_fov: float = DEFAULT_VERTICAL_FOV,
     depth_smoothing: float = DEFAULT_DEPTH_SMOOTHING,
-    output_sharpening: float = DEFAULT_OUTPUT_SHARPENING
+    output_sharpening: float = DEFAULT_OUTPUT_SHARPENING,
+    output_width: int = DEFAULT_OUTPUT_WIDTH,
+    output_height: int = DEFAULT_OUTPUT_HEIGHT
 ) -> Tuple[bool, str]:
     """Generate a VR 180 stereo image from a single image.
 
     Args:
         image_path: Path to the input image
         output_path: Path for the output stereo image
-        eye_separation: Horizontal displacement factor (default 0.03 = 3% of image width)
-        depth_strength: Multiplier for depth-based displacement (default 1.0)
-        equirectangular: Apply equirectangular projection for VR 180 display (default True)
-        vertical_fov: Vertical field of view in degrees (90-180, default 180)
+        eye_separation: Horizontal displacement factor (default 0.015)
+        depth_strength: Multiplier for depth-based displacement (default 0.5)
+        equirectangular: Apply equirectangular projection for VR 180 display (default False)
+        vertical_fov: Vertical field of view in degrees (90-180, default 90)
         depth_smoothing: Gaussian blur sigma for depth map (0 = disabled, default 2.0)
         output_sharpening: Unsharp mask strength for final output (0 = disabled, default 0.3)
+        output_width: Final stereo image width (default 4128 for Quest 3S)
+        output_height: Final stereo image height (default 2208 for Quest 3S)
 
     Returns:
         Tuple of (success, message)
@@ -321,7 +332,13 @@ def generate_stereo_pair(
         # Create side-by-side stereo image (left | right)
         stereo = np.hstack([left_eye, right_eye])
 
-        # Apply output sharpening to restore crispness
+        # Resize to target output dimensions (after depth processing, before sharpening)
+        current_height, current_width = stereo.shape[:2]
+        if current_width != output_width or current_height != output_height:
+            print(f"[VRStereo] Resizing from {current_width}x{current_height} to {output_width}x{output_height}...")
+            stereo = cv2.resize(stereo, (output_width, output_height), interpolation=cv2.INTER_LANCZOS4)
+
+        # Apply output sharpening to restore crispness (after resize to counteract upscaling softness)
         if output_sharpening > 0:
             print(f"[VRStereo] Applying output sharpening (strength={output_sharpening})...")
             stereo = apply_sharpening(stereo, output_sharpening)
@@ -330,7 +347,7 @@ def generate_stereo_pair(
         print(f"[VRStereo] Saving stereo image: {output_path}")
         cv2.imwrite(output_path, stereo, [cv2.IMWRITE_JPEG_QUALITY, 95])
 
-        return True, f"Stereo image generated: {width*2}x{height}"
+        return True, f"Stereo image generated: {output_width}x{output_height}"
 
     except Exception as e:
         print(f"[VRStereo] Error: {e}")

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -546,7 +546,7 @@ class APIClient {
 
   // ============== VR 180 Stereo Images ==============
 
-  async generateVRImage(imagePath, eyeSeparation = 0.03, depthStrength = 1.0, equirectangular = true, verticalFov = 165, depthSmoothing = 2.0, outputSharpening = 0.3) {
+  async generateVRImage(imagePath, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208) {
     const formData = new FormData();
     formData.append('image_path', imagePath);
     formData.append('eye_separation', eyeSeparation.toString());
@@ -555,6 +555,8 @@ class APIClient {
     formData.append('vertical_fov', verticalFov.toString());
     formData.append('depth_smoothing', depthSmoothing.toString());
     formData.append('output_sharpening', outputSharpening.toString());
+    formData.append('output_width', outputWidth.toString());
+    formData.append('output_height', outputHeight.toString());
 
     return this.request('/vr/generate', {
       method: 'POST',

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -30,12 +30,14 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
   const [vrImages, setVrImages] = useState([]);
   const [loadingVRImages, setLoadingVRImages] = useState(false);
   const [vrSettings, setVrSettings] = useState({
-    eyeSeparation: 0.03,
-    depthStrength: 1.0,
-    equirectangular: true,
-    verticalFov: 165,
+    eyeSeparation: 0.015,
+    depthStrength: 0.5,
+    equirectangular: false,
+    verticalFov: 90,
     depthSmoothing: 2.0,
-    outputSharpening: 0.3
+    outputSharpening: 0.3,
+    outputWidth: 4128,
+    outputHeight: 2208
   });
 
   // Lock scroll on .main-content when modal is open
@@ -123,12 +125,14 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         const data = await API.getSettings();
         const s = data.settings || data;
         setVrSettings({
-          eyeSeparation: parseFloat(s.vr_eye_separation) || 0.03,
-          depthStrength: parseFloat(s.vr_depth_strength) || 1.0,
-          equirectangular: s.vr_equirectangular !== 'false',
-          verticalFov: parseInt(s.vr_vertical_fov) || 165,
+          eyeSeparation: parseFloat(s.vr_eye_separation) || 0.015,
+          depthStrength: parseFloat(s.vr_depth_strength) || 0.5,
+          equirectangular: s.vr_equirectangular === 'true',
+          verticalFov: parseInt(s.vr_vertical_fov) || 90,
           depthSmoothing: parseFloat(s.vr_depth_smoothing) || 2.0,
-          outputSharpening: parseFloat(s.vr_output_sharpening) || 0.3
+          outputSharpening: parseFloat(s.vr_output_sharpening) || 0.3,
+          outputWidth: parseInt(s.vr_output_width) || 4128,
+          outputHeight: parseInt(s.vr_output_height) || 2208
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -261,7 +265,9 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         vrSettings.equirectangular,
         vrSettings.verticalFov,
         vrSettings.depthSmoothing,
-        vrSettings.outputSharpening
+        vrSettings.outputSharpening,
+        vrSettings.outputWidth,
+        vrSettings.outputHeight
       );
       const vrId = result.vr_id;
 

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -30,13 +30,13 @@ export default function Settings() {
   const [promptIdentity, setPromptIdentity] = useState('');
   const [slideshowDelay, setSlideshowDelay] = useState(5);
 
-  // VR 180 stereo settings
-  const [vrEyeSeparation, setVrEyeSeparation] = useState(0.03);
-  const [vrDepthStrength, setVrDepthStrength] = useState(1.0);
+  // VR 180 stereo settings (validated for Quest 3S)
+  const [vrEyeSeparation, setVrEyeSeparation] = useState(0.015);
+  const [vrDepthStrength, setVrDepthStrength] = useState(0.5);
   const [vrOutputWidth, setVrOutputWidth] = useState(4128);
   const [vrOutputHeight, setVrOutputHeight] = useState(2208);
-  const [vrEquirectangular, setVrEquirectangular] = useState(true);
-  const [vrVerticalFov, setVrVerticalFov] = useState(165);
+  const [vrEquirectangular, setVrEquirectangular] = useState(false);
+  const [vrVerticalFov, setVrVerticalFov] = useState(90);
   const [vrDepthSmoothing, setVrDepthSmoothing] = useState(2.0);
   const [vrOutputSharpening, setVrOutputSharpening] = useState(0.3);
 
@@ -75,13 +75,13 @@ export default function Settings() {
       setPromptIdentity(s.prompt_identity || '');
       setSlideshowDelay(parseInt(s.slideshow_delay) || 5);
 
-      // VR settings
-      setVrEyeSeparation(parseFloat(s.vr_eye_separation) || 0.03);
-      setVrDepthStrength(parseFloat(s.vr_depth_strength) || 1.0);
+      // VR settings (validated for Quest 3S)
+      setVrEyeSeparation(parseFloat(s.vr_eye_separation) || 0.015);
+      setVrDepthStrength(parseFloat(s.vr_depth_strength) || 0.5);
       setVrOutputWidth(parseInt(s.vr_output_width) || 4128);
       setVrOutputHeight(parseInt(s.vr_output_height) || 2208);
-      setVrEquirectangular(s.vr_equirectangular !== 'false');
-      setVrVerticalFov(parseInt(s.vr_vertical_fov) || 165);
+      setVrEquirectangular(s.vr_equirectangular === 'true');
+      setVrVerticalFov(parseInt(s.vr_vertical_fov) || 90);
       setVrDepthSmoothing(parseFloat(s.vr_depth_smoothing) || 2.0);
       setVrOutputSharpening(parseFloat(s.vr_output_sharpening) || 0.3);
 
@@ -551,7 +551,7 @@ export default function Settings() {
               <input
                 type="number"
                 value={vrEyeSeparation}
-                onChange={(e) => setVrEyeSeparation(parseFloat(e.target.value) || 0.03)}
+                onChange={(e) => setVrEyeSeparation(parseFloat(e.target.value) || 0.015)}
                 min="0.01"
                 max="0.1"
                 step="0.005"
@@ -565,7 +565,7 @@ export default function Settings() {
               <input
                 type="number"
                 value={vrDepthStrength}
-                onChange={(e) => setVrDepthStrength(parseFloat(e.target.value) || 1.0)}
+                onChange={(e) => setVrDepthStrength(parseFloat(e.target.value) || 0.5)}
                 min="0.1"
                 max="3.0"
                 step="0.1"


### PR DESCRIPTION
- Update default parameters to validated Quest 3S settings:
  - Eye separation: 0.015 (reduced from 0.03 to minimize eye strain)
  - Depth strength: 0.5 (moderate 3D effect)
  - Equirectangular: false (disabled - unnecessary at 90° FOV)
  - Vertical FOV: 90° (removes projection correction)
- Add output_width and output_height parameters to generate_stereo_pair()
- Implement LANCZOS4 resize after depth processing, before sharpening to counteract upscaling softness and ensure Quest 3S native resolution
- Update routes.py, database.py, API client, Settings.jsx, and ImagePreviewModal with new parameters and defaults

Closes #208