### PR TITLE
Add Real-ESRGAN upscaling to VR stereo pipeline

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -562,7 +562,11 @@ def init_db():
             "vr_equirectangular": "false",
             "vr_vertical_fov": "90",
             "vr_depth_smoothing": "2.0",
-            "vr_output_sharpening": "0.3"
+            "vr_output_sharpening": "0.3",
+            # Real-ESRGAN upscaling settings
+            "vr_upscale_enabled": "true",
+            "vr_upscale_factor": "2",
+            "vr_upscale_threshold": "1500"
         }
 
         for key, value in default_settings.items():

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2526,7 +2526,10 @@ async def generate_vr_image(
     depth_smoothing: float = Form(2.0),
     output_sharpening: float = Form(0.3),
     output_width: int = Form(4128),
-    output_height: int = Form(2208)
+    output_height: int = Form(2208),
+    upscale_enabled: bool = Form(True),
+    upscale_factor: int = Form(2),
+    upscale_threshold: int = Form(1500)
 ):
     """Start VR 180 stereo image generation for a source image.
 
@@ -2543,6 +2546,9 @@ async def generate_vr_image(
         output_sharpening: Unsharp mask strength for final output (0 = disabled, default 0.3)
         output_width: Final stereo image width (default 4128 for Quest 3S)
         output_height: Final stereo image height (default 2208 for Quest 3S)
+        upscale_enabled: Enable Real-ESRGAN upscaling for low-res sources (default True)
+        upscale_factor: Upscale factor 2 or 4 (default 2)
+        upscale_threshold: Upscale if source width below this (default 1500)
     """
     from database import create_vr_image, update_vr_image_status
     from vr_stereo import generate_stereo_pair, get_vr_output_path, VR_OUTPUT_PATH as VR_PATH
@@ -2582,7 +2588,10 @@ async def generate_vr_image(
                 depth_smoothing=depth_smoothing,
                 output_sharpening=output_sharpening,
                 output_width=output_width,
-                output_height=output_height
+                output_height=output_height,
+                upscale_enabled=upscale_enabled,
+                upscale_factor=upscale_factor,
+                upscale_threshold=upscale_threshold
             )
             if success:
                 update_vr_image_status(vr_id, "completed", output_path=output_path)

--- a/backend/upscaler.py
+++ b/backend/upscaler.py
@@ -1,0 +1,127 @@
+"""Real-ESRGAN image upscaling for VR stereo pipeline."""
+
+import numpy as np
+from typing import Optional
+
+# Lazy-load heavy dependencies
+_upscaler = None
+_current_scale = None
+
+
+def _load_realesrgan(scale: int = 2):
+    """Lazy load Real-ESRGAN model on first use.
+
+    Args:
+        scale: Upscale factor (2 or 4)
+
+    Returns:
+        RealESRGANer instance
+    """
+    global _upscaler, _current_scale
+
+    # Return cached model if scale matches
+    if _upscaler is not None and _current_scale == scale:
+        return _upscaler
+
+    # Unload existing model if scale changed
+    if _upscaler is not None:
+        unload_upscaler()
+
+    import torch
+    from basicsr.archs.rrdbnet_arch import RRDBNet
+    from realesrgan import RealESRGANer
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[Upscaler] Loading Real-ESRGAN {scale}x model on {device}...")
+
+    # Select model based on scale factor
+    if scale == 4:
+        model = RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=4)
+        model_path = None  # Will use default from realesrgan package
+        netscale = 4
+    else:
+        # Use 2x model (RealESRGAN_x2plus)
+        model = RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=2)
+        model_path = None
+        netscale = 2
+
+    _upscaler = RealESRGANer(
+        scale=netscale,
+        model_path=model_path,
+        model=model,
+        tile=0,  # 0 = no tiling (faster for smaller images)
+        tile_pad=10,
+        pre_pad=0,
+        half=torch.cuda.is_available(),  # Use FP16 on GPU
+        device=device
+    )
+    _current_scale = scale
+
+    print(f"[Upscaler] Real-ESRGAN {scale}x model loaded successfully")
+    return _upscaler
+
+
+def unload_upscaler():
+    """Unload Real-ESRGAN model from GPU memory."""
+    global _upscaler, _current_scale
+
+    if _upscaler is None:
+        return
+
+    import torch
+    import gc
+
+    print("[Upscaler] Unloading Real-ESRGAN model...")
+
+    # Clear references
+    _upscaler = None
+    _current_scale = None
+
+    # Force garbage collection
+    gc.collect()
+
+    # Clear CUDA cache if available
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+    print("[Upscaler] Real-ESRGAN model unloaded, GPU memory freed")
+
+
+def upscale_image(
+    image: np.ndarray,
+    scale: int = 2,
+    outscale: Optional[float] = None
+) -> np.ndarray:
+    """Upscale an image using Real-ESRGAN.
+
+    Args:
+        image: Input image as numpy array (BGR format from OpenCV)
+        scale: Model scale factor (2 or 4)
+        outscale: Final output scale (if different from model scale)
+
+    Returns:
+        Upscaled image as numpy array (BGR format)
+    """
+    if scale not in (2, 4):
+        raise ValueError(f"Scale must be 2 or 4, got {scale}")
+
+    upscaler = _load_realesrgan(scale)
+
+    # Real-ESRGAN expects BGR input (OpenCV format)
+    output, _ = upscaler.enhance(image, outscale=outscale or scale)
+
+    return output
+
+
+def should_upscale(width: int, threshold: int = 1500) -> bool:
+    """Determine if an image should be upscaled based on width.
+
+    Args:
+        width: Image width in pixels
+        threshold: Width threshold below which upscaling is recommended
+
+    Returns:
+        True if image should be upscaled
+    """
+    return width < threshold

--- a/backend/vr_stereo.py
+++ b/backend/vr_stereo.py
@@ -97,6 +97,11 @@ DEFAULT_OUTPUT_HEIGHT = 2208     # Quest 3S native height
 DEFAULT_DEPTH_SMOOTHING = 2.0   # Gaussian blur sigma for depth map (0 = disabled)
 DEFAULT_OUTPUT_SHARPENING = 0.3  # Unsharp mask strength (0 = disabled, max ~1.0)
 
+# Real-ESRGAN upscaling defaults
+DEFAULT_UPSCALE_ENABLED = True   # Enable AI upscaling for low-res sources
+DEFAULT_UPSCALE_FACTOR = 2       # 2x or 4x (2x is faster, 4x is higher quality)
+DEFAULT_UPSCALE_THRESHOLD = 1500 # Upscale if source width is below this
+
 
 def smooth_depth_map(depth: np.ndarray, sigma: float = DEFAULT_DEPTH_SMOOTHING) -> np.ndarray:
     """Apply Gaussian blur to depth map to smooth harsh stereo transitions.
@@ -203,11 +208,11 @@ def apply_equirectangular_projection(
     return result
 
 
-def estimate_depth(image_path: str) -> np.ndarray:
+def estimate_depth(image) -> np.ndarray:
     """Estimate depth map from an image using MiDaS.
 
     Args:
-        image_path: Path to the input image
+        image: Either a file path (str) or a numpy array (BGR format from OpenCV)
 
     Returns:
         Depth map as numpy array (higher values = closer to camera)
@@ -217,9 +222,17 @@ def estimate_depth(image_path: str) -> np.ndarray:
 
     model, transform, device = _load_midas()
 
-    # Load and preprocess image
-    img = cv2.imread(image_path)
-    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    # Handle both file path and numpy array input
+    if isinstance(image, str):
+        img = cv2.imread(image)
+        if img is None:
+            raise ValueError(f"Could not load image: {image}")
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    elif isinstance(image, np.ndarray):
+        # Assume BGR format from OpenCV, convert to RGB
+        img = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    else:
+        raise TypeError(f"image must be str or numpy array, got {type(image)}")
 
     input_batch = transform(img).to(device)
 
@@ -250,7 +263,10 @@ def generate_stereo_pair(
     depth_smoothing: float = DEFAULT_DEPTH_SMOOTHING,
     output_sharpening: float = DEFAULT_OUTPUT_SHARPENING,
     output_width: int = DEFAULT_OUTPUT_WIDTH,
-    output_height: int = DEFAULT_OUTPUT_HEIGHT
+    output_height: int = DEFAULT_OUTPUT_HEIGHT,
+    upscale_enabled: bool = DEFAULT_UPSCALE_ENABLED,
+    upscale_factor: int = DEFAULT_UPSCALE_FACTOR,
+    upscale_threshold: int = DEFAULT_UPSCALE_THRESHOLD
 ) -> Tuple[bool, str]:
     """Generate a VR 180 stereo image from a single image.
 
@@ -265,6 +281,9 @@ def generate_stereo_pair(
         output_sharpening: Unsharp mask strength for final output (0 = disabled, default 0.3)
         output_width: Final stereo image width (default 4128 for Quest 3S)
         output_height: Final stereo image height (default 2208 for Quest 3S)
+        upscale_enabled: Enable Real-ESRGAN upscaling for low-res sources (default True)
+        upscale_factor: Upscale factor 2 or 4 (default 2)
+        upscale_threshold: Upscale if source width below this (default 1500)
 
     Returns:
         Tuple of (success, message)
@@ -284,9 +303,26 @@ def generate_stereo_pair(
         height, width = img.shape[:2]
         print(f"[VRStereo] Processing image: {width}x{height}")
 
-        # Estimate depth
+        # AI upscaling for low-resolution sources
+        upscaled = False
+        if upscale_enabled and width < upscale_threshold:
+            try:
+                from upscaler import upscale_image, unload_upscaler
+                print(f"[VRStereo] Source width {width} < threshold {upscale_threshold}, applying Real-ESRGAN {upscale_factor}x upscaling...")
+                img = upscale_image(img, scale=upscale_factor)
+                height, width = img.shape[:2]
+                print(f"[VRStereo] Upscaled to: {width}x{height}")
+                upscaled = True
+                # Unload upscaler to free GPU memory for MiDaS
+                unload_upscaler()
+            except ImportError as e:
+                print(f"[VRStereo] Real-ESRGAN not available, skipping upscale: {e}")
+            except Exception as e:
+                print(f"[VRStereo] Upscaling failed, continuing without: {e}")
+
+        # Estimate depth (pass numpy array if upscaled, otherwise file path)
         print("[VRStereo] Estimating depth...")
-        depth = estimate_depth(image_path)
+        depth = estimate_depth(img if upscaled else image_path)
 
         # Apply depth smoothing to reduce harsh stereo transitions
         if depth_smoothing > 0:

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -546,7 +546,7 @@ class APIClient {
 
   // ============== VR 180 Stereo Images ==============
 
-  async generateVRImage(imagePath, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208) {
+  async generateVRImage(imagePath, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208, upscaleEnabled = true, upscaleFactor = 2, upscaleThreshold = 1500) {
     const formData = new FormData();
     formData.append('image_path', imagePath);
     formData.append('eye_separation', eyeSeparation.toString());
@@ -557,6 +557,9 @@ class APIClient {
     formData.append('output_sharpening', outputSharpening.toString());
     formData.append('output_width', outputWidth.toString());
     formData.append('output_height', outputHeight.toString());
+    formData.append('upscale_enabled', upscaleEnabled.toString());
+    formData.append('upscale_factor', upscaleFactor.toString());
+    formData.append('upscale_threshold', upscaleThreshold.toString());
 
     return this.request('/vr/generate', {
       method: 'POST',

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -37,7 +37,10 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
     depthSmoothing: 2.0,
     outputSharpening: 0.3,
     outputWidth: 4128,
-    outputHeight: 2208
+    outputHeight: 2208,
+    upscaleEnabled: true,
+    upscaleFactor: 2,
+    upscaleThreshold: 1500
   });
 
   // Lock scroll on .main-content when modal is open
@@ -132,7 +135,10 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
           depthSmoothing: parseFloat(s.vr_depth_smoothing) || 2.0,
           outputSharpening: parseFloat(s.vr_output_sharpening) || 0.3,
           outputWidth: parseInt(s.vr_output_width) || 4128,
-          outputHeight: parseInt(s.vr_output_height) || 2208
+          outputHeight: parseInt(s.vr_output_height) || 2208,
+          upscaleEnabled: s.vr_upscale_enabled !== 'false',
+          upscaleFactor: parseInt(s.vr_upscale_factor) || 2,
+          upscaleThreshold: parseInt(s.vr_upscale_threshold) || 1500
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -267,7 +273,10 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         vrSettings.depthSmoothing,
         vrSettings.outputSharpening,
         vrSettings.outputWidth,
-        vrSettings.outputHeight
+        vrSettings.outputHeight,
+        vrSettings.upscaleEnabled,
+        vrSettings.upscaleFactor,
+        vrSettings.upscaleThreshold
       );
       const vrId = result.vr_id;
 

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -39,6 +39,9 @@ export default function Settings() {
   const [vrVerticalFov, setVrVerticalFov] = useState(90);
   const [vrDepthSmoothing, setVrDepthSmoothing] = useState(2.0);
   const [vrOutputSharpening, setVrOutputSharpening] = useState(0.3);
+  const [vrUpscaleEnabled, setVrUpscaleEnabled] = useState(true);
+  const [vrUpscaleFactor, setVrUpscaleFactor] = useState(2);
+  const [vrUpscaleThreshold, setVrUpscaleThreshold] = useState(1500);
 
   useEffect(() => {
     loadSettings();
@@ -84,6 +87,9 @@ export default function Settings() {
       setVrVerticalFov(parseInt(s.vr_vertical_fov) || 90);
       setVrDepthSmoothing(parseFloat(s.vr_depth_smoothing) || 2.0);
       setVrOutputSharpening(parseFloat(s.vr_output_sharpening) || 0.3);
+      setVrUpscaleEnabled(s.vr_upscale_enabled !== 'false');
+      setVrUpscaleFactor(parseInt(s.vr_upscale_factor) || 2);
+      setVrUpscaleThreshold(parseInt(s.vr_upscale_threshold) || 1500);
 
       setLoading(false);
     } catch (error) {
@@ -166,7 +172,10 @@ export default function Settings() {
         vr_equirectangular: String(vrEquirectangular),
         vr_vertical_fov: String(vrVerticalFov),
         vr_depth_smoothing: String(vrDepthSmoothing),
-        vr_output_sharpening: String(vrOutputSharpening)
+        vr_output_sharpening: String(vrOutputSharpening),
+        vr_upscale_enabled: String(vrUpscaleEnabled),
+        vr_upscale_factor: String(vrUpscaleFactor),
+        vr_upscale_threshold: String(vrUpscaleThreshold)
       };
 
       await API.updateSettings(settingsPayload);
@@ -680,6 +689,63 @@ export default function Settings() {
             <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
               Unsharp mask applied to final output to restore crispness. Recommended: 0.3.
             </small>
+          </div>
+
+          <div style={{ marginTop: '20px', paddingTop: '16px', borderTop: '1px solid #333' }}>
+            <h3 style={{ fontSize: '14px', marginBottom: '12px' }}>AI Upscaling (Real-ESRGAN)</h3>
+            <div className="form-group">
+              <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={vrUpscaleEnabled}
+                  onChange={(e) => setVrUpscaleEnabled(e.target.checked)}
+                  style={{ width: 'auto', margin: 0 }}
+                />
+                Enable AI Upscaling
+              </label>
+              <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+                Use Real-ESRGAN to enhance low-resolution source images before VR conversion.
+              </small>
+            </div>
+
+            {vrUpscaleEnabled && (
+              <>
+                <div className="form-group" style={{ marginTop: '12px' }}>
+                  <label>Upscale Factor</label>
+                  <select
+                    value={vrUpscaleFactor}
+                    onChange={(e) => setVrUpscaleFactor(parseInt(e.target.value))}
+                    style={{ width: '100%' }}
+                  >
+                    <option value="2">2x (faster)</option>
+                    <option value="4">4x (higher quality)</option>
+                  </select>
+                  <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+                    2x is faster with good quality. 4x produces sharper results but takes longer.
+                  </small>
+                </div>
+
+                <div className="form-group" style={{ marginTop: '12px' }}>
+                  <label>Width Threshold: {vrUpscaleThreshold}px</label>
+                  <input
+                    type="range"
+                    value={vrUpscaleThreshold}
+                    onChange={(e) => setVrUpscaleThreshold(parseInt(e.target.value))}
+                    min="500"
+                    max="3000"
+                    step="100"
+                    style={{ width: '100%' }}
+                  />
+                  <div style={{ display: 'flex', justifyContent: 'space-between', color: '#666', fontSize: '11px' }}>
+                    <span>500px</span>
+                    <span>3000px</span>
+                  </div>
+                  <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+                    Only upscale images narrower than this threshold. Recommended: 1500px.
+                  </small>
+                </div>
+              </>
+            )}
           </div>
         </div>
         </div>


### PR DESCRIPTION
- Create backend/upscaler.py with lazy-loading Real-ESRGAN model wrapper
- Refactor estimate_depth() to accept numpy arrays (not just file paths)
- Add upscale parameters to generate_stereo_pair():
  - upscale_enabled: Enable AI upscaling (default True)
  - upscale_factor: 2x or 4x scale (default 2)
  - upscale_threshold: Width threshold for triggering upscale (default 1500)
- Add database settings: vr_upscale_enabled, vr_upscale_factor, vr_upscale_threshold
- Update routes.py with new form parameters
- Add UI controls in Settings.jsx (toggle, factor selector, threshold slider)
- Update ImagePreviewModal and API client with new parameters

AI upscaling is applied before depth estimation to enhance low-resolution source images, producing sharper VR output instead of pixelated results.

Closes #210