### PR TITLE
VR Pipeline Improvements (#214)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -592,7 +592,13 @@ def init_db():
             "vr_upscale_factor": "2",
             "vr_upscale_threshold": "1500",
             # Real-ESRGAN upscaling settings for VR videos
-            "vr_video_upscale_enabled": "false"
+            "vr_video_upscale_enabled": "false",
+            # Depth estimation model selection
+            "vr_depth_model": "depth_anything_v2",
+            # VR video encoding preset
+            "vr_encoding_preset": "balanced",
+            # VR video target FPS (30, 60, or 90)
+            "vr_target_fps": "60"
         }
 
         for key, value in default_settings.items():

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -2529,7 +2529,8 @@ async def generate_vr_image(
     output_height: int = Form(2208),
     upscale_enabled: bool = Form(True),
     upscale_factor: int = Form(2),
-    upscale_threshold: int = Form(1500)
+    upscale_threshold: int = Form(1500),
+    depth_model: str = Form("depth_anything_v2")
 ):
     """Start VR 180 stereo image generation for a source image.
 
@@ -2591,7 +2592,8 @@ async def generate_vr_image(
                 output_height=output_height,
                 upscale_enabled=upscale_enabled,
                 upscale_factor=upscale_factor,
-                upscale_threshold=upscale_threshold
+                upscale_threshold=upscale_threshold,
+                depth_model=depth_model
             )
             if success:
                 update_vr_image_status(vr_id, "completed", output_path=output_path)
@@ -2691,7 +2693,9 @@ async def generate_vr_video(
     output_height: int = Form(2208),
     upscale_enabled: bool = Form(False),
     upscale_factor: int = Form(2),
-    upscale_threshold: int = Form(1500)
+    upscale_threshold: int = Form(1500),
+    depth_model: str = Form("depth_anything_v2"),
+    encoding_preset: str = Form("balanced")
 ):
     """Start VR 180 stereo video generation for a job's final video.
 
@@ -2727,7 +2731,9 @@ async def generate_vr_video(
         "output_height": output_height,
         "upscale_enabled": upscale_enabled,
         "upscale_factor": upscale_factor,
-        "upscale_threshold": upscale_threshold
+        "upscale_threshold": upscale_threshold,
+        "depth_model": depth_model,
+        "encoding_preset": encoding_preset
     }
     vr_video_id = create_vr_video(job_id, source_video, settings)
 
@@ -2762,6 +2768,8 @@ async def generate_vr_video(
                 upscale_enabled=upscale_enabled,
                 upscale_factor=upscale_factor,
                 upscale_threshold=upscale_threshold,
+                depth_model=depth_model,
+                encoding_preset=encoding_preset,
                 progress_callback=progress_callback
             )
             if success:

--- a/backend/vr_stereo.py
+++ b/backend/vr_stereo.py
@@ -1,9 +1,9 @@
-"""VR 180 Stereo Image Generation using MiDaS depth estimation."""
+"""VR 180 Stereo Image Generation using depth estimation (MiDaS or Depth Anything V2)."""
 
 import os
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Literal
 import numpy as np
 
 # Check for required environment variable
@@ -17,43 +17,86 @@ else:
         VR_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
         print(f"[VRStereo] Created output directory: {VR_OUTPUT_DIR}")
 
-# Lazy-load heavy dependencies
+# Supported depth estimation models
+DEPTH_MODEL_MIDAS = "midas"
+DEPTH_MODEL_DEPTH_ANYTHING = "depth_anything_v2"
+DEFAULT_DEPTH_MODEL = DEPTH_MODEL_DEPTH_ANYTHING  # Depth Anything V2 is recommended
+
+# Lazy-load heavy dependencies - MiDaS
 _midas_model = None
 _midas_transform = None
-_device = None
+_midas_device = None
+
+# Lazy-load heavy dependencies - Depth Anything V2
+_depth_anything_model = None
+_depth_anything_processor = None
+_depth_anything_device = None
+
+# Track which model is currently loaded
+_current_depth_model = None
 
 
 def _load_midas():
     """Lazy load MiDaS model on first use."""
-    global _midas_model, _midas_transform, _device
+    global _midas_model, _midas_transform, _midas_device, _current_depth_model
 
     if _midas_model is not None:
-        return _midas_model, _midas_transform, _device
+        return _midas_model, _midas_transform, _midas_device
+
+    # Unload other model if loaded
+    if _current_depth_model == DEPTH_MODEL_DEPTH_ANYTHING:
+        _unload_depth_anything()
 
     import torch
 
-    _device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"[VRStereo] Loading MiDaS model on {_device}...")
+    _midas_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[VRStereo] Loading MiDaS model on {_midas_device}...")
 
     # Use MiDaS v3.1 DPT-Large for best quality
     _midas_model = torch.hub.load("intel-isl/MiDaS", "DPT_Large")
-    _midas_model.to(_device)
+    _midas_model.to(_midas_device)
     _midas_model.eval()
 
     midas_transforms = torch.hub.load("intel-isl/MiDaS", "transforms")
     _midas_transform = midas_transforms.dpt_transform
 
+    _current_depth_model = DEPTH_MODEL_MIDAS
     print("[VRStereo] MiDaS model loaded successfully")
-    return _midas_model, _midas_transform, _device
+    return _midas_model, _midas_transform, _midas_device
 
 
-def unload_midas_model():
-    """Unload MiDaS model from GPU memory to free VRAM.
+def _load_depth_anything():
+    """Lazy load Depth Anything V2 model on first use."""
+    global _depth_anything_model, _depth_anything_processor, _depth_anything_device, _current_depth_model
 
-    This should be called after VR generation is complete to release
-    GPU memory for other tasks (like video generation).
-    """
-    global _midas_model, _midas_transform, _device
+    if _depth_anything_model is not None:
+        return _depth_anything_model, _depth_anything_processor, _depth_anything_device
+
+    # Unload other model if loaded
+    if _current_depth_model == DEPTH_MODEL_MIDAS:
+        _unload_midas()
+
+    import torch
+    from transformers import AutoImageProcessor, AutoModelForDepthEstimation
+
+    _depth_anything_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[VRStereo] Loading Depth Anything V2 model on {_depth_anything_device}...")
+
+    # Use Depth Anything V2 Large for best quality
+    model_name = "depth-anything/Depth-Anything-V2-Large-hf"
+    _depth_anything_processor = AutoImageProcessor.from_pretrained(model_name)
+    _depth_anything_model = AutoModelForDepthEstimation.from_pretrained(model_name)
+    _depth_anything_model.to(_depth_anything_device)
+    _depth_anything_model.eval()
+
+    _current_depth_model = DEPTH_MODEL_DEPTH_ANYTHING
+    print("[VRStereo] Depth Anything V2 model loaded successfully")
+    return _depth_anything_model, _depth_anything_processor, _depth_anything_device
+
+
+def _unload_midas():
+    """Unload MiDaS model from GPU memory."""
+    global _midas_model, _midas_transform, _midas_device, _current_depth_model
 
     if _midas_model is None:
         return
@@ -63,23 +106,59 @@ def unload_midas_model():
 
     print("[VRStereo] Unloading MiDaS model...")
 
-    # Move model to CPU first (releases GPU memory)
     _midas_model.to("cpu")
-
-    # Clear references
     _midas_model = None
     _midas_transform = None
-    _device = None
+    _midas_device = None
 
-    # Force garbage collection
+    if _current_depth_model == DEPTH_MODEL_MIDAS:
+        _current_depth_model = None
+
     gc.collect()
-
-    # Clear CUDA cache if available
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 
-    print("[VRStereo] MiDaS model unloaded, GPU memory freed")
+    print("[VRStereo] MiDaS model unloaded")
+
+
+def _unload_depth_anything():
+    """Unload Depth Anything V2 model from GPU memory."""
+    global _depth_anything_model, _depth_anything_processor, _depth_anything_device, _current_depth_model
+
+    if _depth_anything_model is None:
+        return
+
+    import torch
+    import gc
+
+    print("[VRStereo] Unloading Depth Anything V2 model...")
+
+    _depth_anything_model.to("cpu")
+    _depth_anything_model = None
+    _depth_anything_processor = None
+    _depth_anything_device = None
+
+    if _current_depth_model == DEPTH_MODEL_DEPTH_ANYTHING:
+        _current_depth_model = None
+
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+    print("[VRStereo] Depth Anything V2 model unloaded")
+
+
+def unload_midas_model():
+    """Unload depth estimation model from GPU memory to free VRAM.
+
+    This should be called after VR generation is complete to release
+    GPU memory for other tasks (like video generation).
+    """
+    _unload_midas()
+    _unload_depth_anything()
+    print("[VRStereo] Depth models unloaded, GPU memory freed")
 
 
 # Default FOV values for equirectangular projection
@@ -208,11 +287,12 @@ def apply_equirectangular_projection(
     return result
 
 
-def estimate_depth(image) -> np.ndarray:
-    """Estimate depth map from an image using MiDaS.
+def estimate_depth(image, depth_model: str = DEFAULT_DEPTH_MODEL) -> np.ndarray:
+    """Estimate depth map from an image using specified model.
 
     Args:
         image: Either a file path (str) or a numpy array (BGR format from OpenCV)
+        depth_model: Which depth model to use ("midas" or "depth_anything_v2")
 
     Returns:
         Depth map as numpy array (higher values = closer to camera)
@@ -220,30 +300,77 @@ def estimate_depth(image) -> np.ndarray:
     import torch
     import cv2
 
-    model, transform, device = _load_midas()
-
     # Handle both file path and numpy array input
     if isinstance(image, str):
         img = cv2.imread(image)
         if img is None:
             raise ValueError(f"Could not load image: {image}")
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     elif isinstance(image, np.ndarray):
         # Assume BGR format from OpenCV, convert to RGB
-        img = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        img_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     else:
         raise TypeError(f"image must be str or numpy array, got {type(image)}")
 
-    input_batch = transform(img).to(device)
+    if depth_model == DEPTH_MODEL_MIDAS:
+        depth = _estimate_depth_midas(img_rgb)
+    elif depth_model == DEPTH_MODEL_DEPTH_ANYTHING:
+        depth = _estimate_depth_anything(img_rgb)
+    else:
+        raise ValueError(f"Unknown depth model: {depth_model}. Use '{DEPTH_MODEL_MIDAS}' or '{DEPTH_MODEL_DEPTH_ANYTHING}'")
+
+    return depth
+
+
+def _estimate_depth_midas(img_rgb: np.ndarray) -> np.ndarray:
+    """Estimate depth using MiDaS model."""
+    import torch
+
+    model, transform, device = _load_midas()
+
+    input_batch = transform(img_rgb).to(device)
 
     with torch.no_grad():
         prediction = model(input_batch)
         prediction = torch.nn.functional.interpolate(
             prediction.unsqueeze(1),
-            size=img.shape[:2],
+            size=img_rgb.shape[:2],
             mode="bicubic",
             align_corners=False,
         ).squeeze()
+
+    depth = prediction.cpu().numpy()
+
+    # Normalize depth to 0-1 range
+    depth = (depth - depth.min()) / (depth.max() - depth.min() + 1e-8)
+
+    return depth
+
+
+def _estimate_depth_anything(img_rgb: np.ndarray) -> np.ndarray:
+    """Estimate depth using Depth Anything V2 model."""
+    import torch
+    from PIL import Image
+
+    model, processor, device = _load_depth_anything()
+
+    # Convert numpy array to PIL Image
+    pil_image = Image.fromarray(img_rgb)
+
+    # Process image
+    inputs = processor(images=pil_image, return_tensors="pt").to(device)
+
+    with torch.no_grad():
+        outputs = model(**inputs)
+        predicted_depth = outputs.predicted_depth
+
+    # Interpolate to original size
+    prediction = torch.nn.functional.interpolate(
+        predicted_depth.unsqueeze(1),
+        size=img_rgb.shape[:2],
+        mode="bicubic",
+        align_corners=False,
+    ).squeeze()
 
     depth = prediction.cpu().numpy()
 
@@ -266,7 +393,8 @@ def generate_stereo_pair(
     output_height: int = DEFAULT_OUTPUT_HEIGHT,
     upscale_enabled: bool = DEFAULT_UPSCALE_ENABLED,
     upscale_factor: int = DEFAULT_UPSCALE_FACTOR,
-    upscale_threshold: int = DEFAULT_UPSCALE_THRESHOLD
+    upscale_threshold: int = DEFAULT_UPSCALE_THRESHOLD,
+    depth_model: str = DEFAULT_DEPTH_MODEL
 ) -> Tuple[bool, str]:
     """Generate a VR 180 stereo image from a single image.
 
@@ -284,6 +412,7 @@ def generate_stereo_pair(
         upscale_enabled: Enable Real-ESRGAN upscaling for low-res sources (default True)
         upscale_factor: Upscale factor 2 or 4 (default 2)
         upscale_threshold: Upscale if source width below this (default 1500)
+        depth_model: Depth estimation model ("midas" or "depth_anything_v2", default "depth_anything_v2")
 
     Returns:
         Tuple of (success, message)
@@ -321,8 +450,8 @@ def generate_stereo_pair(
                 print(f"[VRStereo] Upscaling failed, continuing without: {e}")
 
         # Estimate depth (pass numpy array if upscaled, otherwise file path)
-        print("[VRStereo] Estimating depth...")
-        depth = estimate_depth(img if upscaled else image_path)
+        print(f"[VRStereo] Estimating depth using {depth_model}...")
+        depth = estimate_depth(img if upscaled else image_path, depth_model=depth_model)
 
         # Apply depth smoothing to reduce harsh stereo transitions
         if depth_smoothing > 0:

--- a/backend/vr_video.py
+++ b/backend/vr_video.py
@@ -1,4 +1,4 @@
-"""VR 180 Stereo Video Conversion using MiDaS depth estimation."""
+"""VR 180 Stereo Video Conversion using depth estimation."""
 
 import os
 import sys
@@ -7,8 +7,60 @@ import subprocess
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional, Tuple, Callable
+from typing import Optional, Tuple, Callable, Dict, Any
 import numpy as np
+
+# Video encoding presets for VR output
+# Based on Quest 3S requirements and quality/speed tradeoffs
+ENCODING_PRESETS: Dict[str, Dict[str, Any]] = {
+    "high_quality": {
+        "name": "High Quality",
+        "description": "Best quality, larger file size. H.265/HEVC CRF 17.",
+        "codec": "libx265",
+        "crf": "17",
+        "preset": "medium",
+        "extra_args": ["-tag:v", "hvc1"],  # Apple/Quest compatibility tag
+    },
+    "balanced": {
+        "name": "Balanced",
+        "description": "Good quality with reasonable file size. H.265/HEVC CRF 18.",
+        "codec": "libx265",
+        "crf": "18",
+        "preset": "medium",
+        "extra_args": ["-tag:v", "hvc1"],
+    },
+    "fast": {
+        "name": "Fast Encode",
+        "description": "Faster encoding, slightly lower quality. H.265/HEVC CRF 20.",
+        "codec": "libx265",
+        "crf": "20",
+        "preset": "fast",
+        "extra_args": ["-tag:v", "hvc1"],
+    },
+    "legacy_h264": {
+        "name": "Legacy H.264",
+        "description": "Maximum compatibility. H.264/AVC CRF 18.",
+        "codec": "libx264",
+        "crf": "18",
+        "preset": "medium",
+        "extra_args": [],
+    },
+}
+
+DEFAULT_ENCODING_PRESET = "balanced"
+
+
+def get_encoding_preset(preset_name: str) -> Dict[str, Any]:
+    """Get encoding preset configuration by name.
+
+    Args:
+        preset_name: Name of the preset (high_quality, balanced, fast, legacy_h264)
+
+    Returns:
+        Preset configuration dict, or balanced preset if name not found.
+    """
+    return ENCODING_PRESETS.get(preset_name, ENCODING_PRESETS[DEFAULT_ENCODING_PRESET])
+
 
 # Check for required environment variable
 VR_OUTPUT_PATH = os.environ.get("VR_OUTPUT_PATH")
@@ -132,7 +184,8 @@ def process_frame_to_stereo(
     depth_strength: float = 0.5,
     equirectangular: bool = False,
     vertical_fov: float = 90,
-    depth_smoothing: float = 2.0
+    depth_smoothing: float = 2.0,
+    depth_model: str = "depth_anything_v2"
 ) -> np.ndarray:
     """Convert a single frame to stereo pair.
 
@@ -143,6 +196,7 @@ def process_frame_to_stereo(
         equirectangular: Apply equirectangular projection
         vertical_fov: Vertical field of view in degrees
         depth_smoothing: Gaussian blur sigma for depth map
+        depth_model: Depth estimation model ("midas" or "depth_anything_v2")
 
     Returns:
         Stereo pair as numpy array (side-by-side)
@@ -156,7 +210,7 @@ def process_frame_to_stereo(
     height, width = frame.shape[:2]
 
     # Estimate depth from frame
-    depth = estimate_depth(frame)
+    depth = estimate_depth(frame, depth_model=depth_model)
 
     # Apply depth smoothing
     if depth_smoothing > 0:
@@ -216,6 +270,7 @@ def process_frames_to_stereo(
     upscale_enabled: bool = False,
     upscale_factor: int = 2,
     upscale_threshold: int = 1500,
+    depth_model: str = "depth_anything_v2",
     progress_callback: Optional[Callable[[int, int, str], None]] = None
 ) -> Tuple[bool, str]:
     """Process all extracted frames to stereo pairs.
@@ -227,6 +282,7 @@ def process_frames_to_stereo(
         upscale_enabled: Enable Real-ESRGAN upscaling for low-res frames
         upscale_factor: Upscale factor 2 or 4
         upscale_threshold: Upscale if frame width below this
+        depth_model: Depth estimation model ("midas" or "depth_anything_v2")
         progress_callback: Optional callback(current_frame, total_frames, stage)
 
     Returns:
@@ -288,7 +344,8 @@ def process_frames_to_stereo(
                 depth_strength=depth_strength,
                 equirectangular=equirectangular,
                 vertical_fov=vertical_fov,
-                depth_smoothing=depth_smoothing
+                depth_smoothing=depth_smoothing,
+                depth_model=depth_model
             )
 
             # Resize to output dimensions
@@ -324,7 +381,8 @@ def reassemble_video(
     frames_dir: str,
     output_path: str,
     fps: float,
-    source_video: Optional[str] = None
+    source_video: Optional[str] = None,
+    encoding_preset: str = DEFAULT_ENCODING_PRESET
 ) -> Tuple[bool, str]:
     """Reassemble stereo frames into a video, optionally with audio from source.
 
@@ -333,11 +391,21 @@ def reassemble_video(
         output_path: Path for output video
         fps: Frame rate for output video
         source_video: Optional source video to copy audio from
+        encoding_preset: Encoding preset name (high_quality, balanced, fast, legacy_h264)
 
     Returns:
         Tuple of (success, message)
     """
     try:
+        # Get encoding preset configuration
+        preset = get_encoding_preset(encoding_preset)
+        codec = preset["codec"]
+        crf = preset["crf"]
+        speed_preset = preset["preset"]
+        extra_args = preset["extra_args"]
+
+        print(f"[VRVideo] Using encoding preset: {preset['name']} ({codec} CRF {crf})")
+
         # Build ffmpeg command
         cmd = [
             "ffmpeg",
@@ -347,24 +415,28 @@ def reassemble_video(
         ]
 
         # Add audio from source if available
+        has_audio = False
         if source_video:
             # Check if source has audio
             info = get_video_info(source_video)
             if info and info.get("has_audio"):
+                has_audio = True
                 cmd.extend(["-i", source_video, "-map", "0:v", "-map", "1:a", "-shortest"])
 
+        # Video encoding settings
         cmd.extend([
-            "-c:v", "libx264",
-            "-preset", "medium",
-            "-crf", "18",
+            "-c:v", codec,
+            "-preset", speed_preset,
+            "-crf", crf,
             "-pix_fmt", "yuv420p",
         ])
 
-        # Copy audio codec if we have audio
-        if source_video:
-            info = get_video_info(source_video)
-            if info and info.get("has_audio"):
-                cmd.extend(["-c:a", "aac", "-b:a", "192k"])
+        # Add codec-specific extra arguments (e.g., hvc1 tag for HEVC)
+        cmd.extend(extra_args)
+
+        # Audio encoding if we have audio
+        if has_audio:
+            cmd.extend(["-c:a", "aac", "-b:a", "192k"])
 
         cmd.append(output_path)
 
@@ -399,6 +471,8 @@ def convert_video_to_vr180(
     upscale_enabled: bool = False,
     upscale_factor: int = 2,
     upscale_threshold: int = 1500,
+    depth_model: str = "depth_anything_v2",
+    encoding_preset: str = DEFAULT_ENCODING_PRESET,
     progress_callback: Optional[Callable[[int, int, str], None]] = None
 ) -> Tuple[bool, str]:
     """Main pipeline: Convert a regular video to VR 180 stereo video.
@@ -409,6 +483,8 @@ def convert_video_to_vr180(
         upscale_enabled: Enable Real-ESRGAN upscaling for low-res frames
         upscale_factor: Upscale factor 2 or 4
         upscale_threshold: Upscale if frame width below this
+        depth_model: Depth estimation model ("midas" or "depth_anything_v2")
+        encoding_preset: Video encoding preset (high_quality, balanced, fast, legacy_h264)
         progress_callback: Optional callback(current, total, stage) for progress updates
 
     Returns:
@@ -467,6 +543,7 @@ def convert_video_to_vr180(
             upscale_enabled=upscale_enabled,
             upscale_factor=upscale_factor,
             upscale_threshold=upscale_threshold,
+            depth_model=depth_model,
             progress_callback=progress_callback
         )
 
@@ -478,7 +555,7 @@ def convert_video_to_vr180(
         if progress_callback:
             progress_callback(frame_count, frame_count, "reassembling")
 
-        success, message = reassemble_video(stereo_dir, output_path, fps, video_path)
+        success, message = reassemble_video(stereo_dir, output_path, fps, video_path, encoding_preset)
         if not success:
             return False, f"Video reassembly failed: {message}"
 

--- a/backend/workflow_templates.py
+++ b/backend/workflow_templates.py
@@ -205,14 +205,14 @@ def calculate_generation_params(target_fps: int, duration_sec: float) -> Dict[st
     """Calculate internal generation parameters from user-facing target fps.
 
     Args:
-        target_fps: User-selected output fps (30 or 60)
+        target_fps: User-selected output fps (30, 60, or 90)
         duration_sec: Video duration in seconds
 
     Returns:
         Dict with:
         - generation_fps: Base fps before interpolation (always 15)
         - wan_frames: Number of frames for WanImageToVideo node
-        - rife_multiplier: RIFE interpolation factor (2 for 30fps, 4 for 60fps)
+        - rife_multiplier: RIFE interpolation factor (2 for 30fps, 4 for 60fps, 6 for 90fps)
         - output_fps: Final output fps (same as target_fps)
     """
     # Calculate RIFE multiplier to reach target fps from 15fps base
@@ -255,7 +255,7 @@ def build_wan_i2v_workflow(
         width: Video width in pixels
         height: Video height in pixels
         duration_sec: Video duration in seconds (default 5.0)
-        target_fps: Output fps - 30 or 60 (uses RIFE 2x or 4x interpolation)
+        target_fps: Output fps - 30, 60, or 90 (uses RIFE 2x, 4x, or 6x interpolation)
         start_image_filename: Filename of the uploaded start image
         high_noise_model: UNET model for high noise pass
         low_noise_model: UNET model for low noise pass

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -546,7 +546,7 @@ class APIClient {
 
   // ============== VR 180 Stereo Images ==============
 
-  async generateVRImage(imagePath, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208, upscaleEnabled = true, upscaleFactor = 2, upscaleThreshold = 1500) {
+  async generateVRImage(imagePath, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208, upscaleEnabled = true, upscaleFactor = 2, upscaleThreshold = 1500, depthModel = 'depth_anything_v2') {
     const formData = new FormData();
     formData.append('image_path', imagePath);
     formData.append('eye_separation', eyeSeparation.toString());
@@ -560,6 +560,7 @@ class APIClient {
     formData.append('upscale_enabled', upscaleEnabled.toString());
     formData.append('upscale_factor', upscaleFactor.toString());
     formData.append('upscale_threshold', upscaleThreshold.toString());
+    formData.append('depth_model', depthModel);
 
     return this.request('/vr/generate', {
       method: 'POST',
@@ -587,7 +588,7 @@ class APIClient {
 
   // ============== VR 180 Stereo Videos ==============
 
-  async generateVRVideo(jobId, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208, upscaleEnabled = false, upscaleFactor = 2, upscaleThreshold = 1500) {
+  async generateVRVideo(jobId, eyeSeparation = 0.015, depthStrength = 0.5, equirectangular = false, verticalFov = 90, depthSmoothing = 2.0, outputSharpening = 0.3, outputWidth = 4128, outputHeight = 2208, upscaleEnabled = false, upscaleFactor = 2, upscaleThreshold = 1500, depthModel = 'depth_anything_v2', encodingPreset = 'balanced') {
     const formData = new FormData();
     formData.append('job_id', jobId.toString());
     formData.append('eye_separation', eyeSeparation.toString());
@@ -601,6 +602,8 @@ class APIClient {
     formData.append('upscale_enabled', upscaleEnabled.toString());
     formData.append('upscale_factor', upscaleFactor.toString());
     formData.append('upscale_threshold', upscaleThreshold.toString());
+    formData.append('depth_model', depthModel);
+    formData.append('encoding_preset', encodingPreset);
 
     return this.request('/vr-video/generate', {
       method: 'POST',

--- a/react-app/src/components/CreateJobModal.jsx
+++ b/react-app/src/components/CreateJobModal.jsx
@@ -468,11 +468,12 @@ export default function CreateJobModal({ onClose, onSuccess, preUploadedImageUrl
                 <MenuItem value={10}>10 sec</MenuItem>
               </Select>
             </FormControl>
-            <FormControl variant="outlined" size="small" sx={{ width: '120px' }}>
+            <FormControl variant="outlined" size="small" sx={{ width: '140px' }}>
               <InputLabel>Output FPS</InputLabel>
               <Select value={targetFps} onChange={(e) => setTargetFps(parseInt(e.target.value))} label="Output FPS">
                 <MenuItem value={30}>30 fps</MenuItem>
                 <MenuItem value={60}>60 fps</MenuItem>
+                <MenuItem value={90}>90 fps</MenuItem>
               </Select>
             </FormControl>
           </div>

--- a/react-app/src/components/EditJobModal.jsx
+++ b/react-app/src/components/EditJobModal.jsx
@@ -269,11 +269,12 @@ export default function EditJobModal({ job, onClose, onSuccess }) {
                 <MenuItem value={10}>10 sec</MenuItem>
               </Select>
             </FormControl>
-            <FormControl variant="outlined" size="small" sx={{ width: '120px' }} disabled={hasStarted}>
+            <FormControl variant="outlined" size="small" sx={{ width: '140px' }} disabled={hasStarted}>
               <InputLabel>Output FPS</InputLabel>
               <Select value={targetFps} onChange={(e) => setTargetFps(parseInt(e.target.value))} label="Output FPS">
                 <MenuItem value={30}>30 fps</MenuItem>
                 <MenuItem value={60}>60 fps</MenuItem>
+                <MenuItem value={90}>90 fps</MenuItem>
               </Select>
             </FormControl>
           </div>

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -40,7 +40,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
     outputHeight: 2208,
     upscaleEnabled: true,
     upscaleFactor: 2,
-    upscaleThreshold: 1500
+    upscaleThreshold: 1500,
+    depthModel: 'depth_anything_v2'
   });
 
   // Lock scroll on .main-content when modal is open
@@ -138,7 +139,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
           outputHeight: parseInt(s.vr_output_height) || 2208,
           upscaleEnabled: s.vr_upscale_enabled !== 'false',
           upscaleFactor: parseInt(s.vr_upscale_factor) || 2,
-          upscaleThreshold: parseInt(s.vr_upscale_threshold) || 1500
+          upscaleThreshold: parseInt(s.vr_upscale_threshold) || 1500,
+          depthModel: s.vr_depth_model || 'depth_anything_v2'
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -276,7 +278,8 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
         vrSettings.outputHeight,
         vrSettings.upscaleEnabled,
         vrSettings.upscaleFactor,
-        vrSettings.upscaleThreshold
+        vrSettings.upscaleThreshold,
+        vrSettings.depthModel
       );
       const vrId = result.vr_id;
 

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -87,7 +87,9 @@ export default function JobDetail() {
     outputHeight: 2208,
     upscaleEnabled: false,
     upscaleFactor: 2,
-    upscaleThreshold: 1500
+    upscaleThreshold: 1500,
+    depthModel: 'depth_anything_v2',
+    encodingPreset: 'balanced'
   });
   const autoFinalizeTriggeredRef = useRef(false);
 
@@ -289,7 +291,9 @@ export default function JobDetail() {
           outputHeight: parseInt(s.vr_output_height) || 2208,
           upscaleEnabled: s.vr_video_upscale_enabled === 'true',
           upscaleFactor: parseInt(s.vr_upscale_factor) || 2,
-          upscaleThreshold: parseInt(s.vr_upscale_threshold) || 1500
+          upscaleThreshold: parseInt(s.vr_upscale_threshold) || 1500,
+          depthModel: s.vr_depth_model || 'depth_anything_v2',
+          encodingPreset: s.vr_encoding_preset || 'balanced'
         });
       } catch (error) {
         console.error('Failed to load VR settings:', error);
@@ -472,7 +476,9 @@ export default function JobDetail() {
         vrSettings.outputHeight,
         vrSettings.upscaleEnabled,
         vrSettings.upscaleFactor,
-        vrSettings.upscaleThreshold
+        vrSettings.upscaleThreshold,
+        vrSettings.depthModel,
+        vrSettings.encodingPreset
       );
       const vrVideoId = result.vr_video_id;
 

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -43,6 +43,8 @@ export default function Settings() {
   const [vrUpscaleFactor, setVrUpscaleFactor] = useState(2);
   const [vrUpscaleThreshold, setVrUpscaleThreshold] = useState(1500);
   const [vrVideoUpscaleEnabled, setVrVideoUpscaleEnabled] = useState(false);
+  const [vrDepthModel, setVrDepthModel] = useState('depth_anything_v2');
+  const [vrEncodingPreset, setVrEncodingPreset] = useState('balanced');
 
   useEffect(() => {
     loadSettings();
@@ -92,6 +94,8 @@ export default function Settings() {
       setVrUpscaleFactor(parseInt(s.vr_upscale_factor) || 2);
       setVrUpscaleThreshold(parseInt(s.vr_upscale_threshold) || 1500);
       setVrVideoUpscaleEnabled(s.vr_video_upscale_enabled === 'true');
+      setVrDepthModel(s.vr_depth_model || 'depth_anything_v2');
+      setVrEncodingPreset(s.vr_encoding_preset || 'balanced');
 
       setLoading(false);
     } catch (error) {
@@ -178,7 +182,9 @@ export default function Settings() {
         vr_upscale_enabled: String(vrUpscaleEnabled),
         vr_upscale_factor: String(vrUpscaleFactor),
         vr_upscale_threshold: String(vrUpscaleThreshold),
-        vr_video_upscale_enabled: String(vrVideoUpscaleEnabled)
+        vr_video_upscale_enabled: String(vrVideoUpscaleEnabled),
+        vr_depth_model: vrDepthModel,
+        vr_encoding_preset: vrEncodingPreset
       };
 
       await API.updateSettings(settingsPayload);
@@ -516,6 +522,7 @@ export default function Settings() {
               >
                 <option value={30}>30 fps</option>
                 <option value={60}>60 fps</option>
+                <option value={90}>90 fps (Quest 3S)</option>
               </select>
             </div>
           </div>
@@ -554,9 +561,44 @@ export default function Settings() {
         <div className="card settings-section">
           <h2>VR 180 Stereo</h2>
           <p style={{ color: '#666', fontSize: '14px', marginBottom: '16px' }}>
-            Settings for generating VR 180° stereoscopic images using MiDaS depth estimation.
+            Settings for generating VR 180° stereoscopic images and videos.
             Optimized for Meta Quest 3S.
           </p>
+
+          {/* Depth Model Selection */}
+          <div className="form-group" style={{ marginBottom: '20px' }}>
+            <label>Depth Estimation Model</label>
+            <select
+              value={vrDepthModel}
+              onChange={(e) => setVrDepthModel(e.target.value)}
+              style={{ width: '100%' }}
+            >
+              <option value="depth_anything_v2">Depth Anything V2 Large (recommended)</option>
+              <option value="midas">MiDaS DPT-Large (legacy)</option>
+            </select>
+            <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+              Depth Anything V2 produces more accurate depth maps with better edge detection. MiDaS is the legacy option.
+            </small>
+          </div>
+
+          {/* Video Encoding Preset */}
+          <div className="form-group" style={{ marginBottom: '20px' }}>
+            <label>Video Encoding Preset</label>
+            <select
+              value={vrEncodingPreset}
+              onChange={(e) => setVrEncodingPreset(e.target.value)}
+              style={{ width: '100%' }}
+            >
+              <option value="high_quality">High Quality (H.265 CRF 17)</option>
+              <option value="balanced">Balanced (H.265 CRF 18) - recommended</option>
+              <option value="fast">Fast Encode (H.265 CRF 20)</option>
+              <option value="legacy_h264">Legacy H.264 (CRF 18)</option>
+            </select>
+            <small style={{ color: '#666', fontSize: '12px', marginTop: '4px', display: 'block' }}>
+              H.265/HEVC offers better quality at smaller file sizes. Use Legacy H.264 for maximum compatibility with older devices.
+            </small>
+          </div>
+
           <div className="settings-grid">
             <div className="form-group">
               <label>Eye Separation</label>


### PR DESCRIPTION
Part 1: Add Depth Anything V2 model support
- Replace MiDaS as default with Depth Anything V2 Large
- Add model selection dropdown in Settings (depth_anything_v2 or midas)
- Implement lazy loading with automatic GPU memory management
- Models auto-unload when switching to prevent VRAM issues

Part 2: Add 90fps output option
- Add 90fps option to video generation (Settings, CreateJob, EditJob)
- Uses RIFE 6x interpolation from 15fps base
- Optimized for Quest 3S 90Hz native refresh rate

Part 3: Video encoding presets
- High Quality: H.265 CRF 17 (best quality, larger files)
- Balanced: H.265 CRF 18 (recommended default)
- Fast Encode: H.265 CRF 20 (faster processing)
- Legacy H.264: CRF 18 (maximum compatibility)
- Add encoding preset dropdown to VR Settings