### PR TITLE
Fix Dashboard sorting to match Queue page

### DIFF
--- a/react-app/src/pages/Dashboard.jsx
+++ b/react-app/src/pages/Dashboard.jsx
@@ -104,6 +104,11 @@ export default function Dashboard() {
         return priorityA - priorityB;
       }
 
+      // Sort pending jobs by their queue priority
+      if (a.status === 'pending') {
+        return (a.priority || 0) - (b.priority || 0);
+      }
+
       const dateA = a.last_segment_run ? new Date(a.last_segment_run) : null;
       const dateB = b.last_segment_run ? new Date(b.last_segment_run) : null;
 


### PR DESCRIPTION
Added missing priority-based sorting for pending jobs. Both pages now use identical sorting logic:
1. Status priority (awaiting_prompt > running > pending > completed/failed/paused)
2. Pending jobs sorted by queue priority
3. Other jobs sorted by last_segment_run date