### PR TITLE
Fix urllib import scope error in faceswap source handling

### DIFF
--- a/backend/queue_manager.py
+++ b/backend/queue_manager.py
@@ -652,7 +652,6 @@ class QueueManager:
                     # Check if it's an end_frame_url (ComfyUI URL)
                     # Format: http://localhost:8188/view?filename=xxx&subfolder=&type=output
                     if 'filename=' in faceswap_source_image:
-                        import urllib.parse
                         parsed = urllib.parse.urlparse(faceswap_source_image)
                         params = urllib.parse.parse_qs(parsed.query)
                         filename = params.get('filename', [''])[0]


### PR DESCRIPTION
Remove redundant 'import urllib.parse' inside conditional block that was shadowing the module-level import and causing "cannot access local variable 'urllib'" error when the code path wasn't taken.