### PR TITLE
Add _HN. and _LN. patterns for LoRA grouping

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1811,6 +1811,7 @@ def _get_lora_base_and_type(filename: str) -> tuple:
         r'-H\.',  # -H at end of name (before extension)
         r'_H\.',
         r'[_-]HN[_-]',
+        r'_HN\.',  # _HN at end of name (before extension)
         r'_high_',
         r'-high-',
         r'_high\.',
@@ -1831,6 +1832,7 @@ def _get_lora_base_and_type(filename: str) -> tuple:
         r'-L\.',  # -L at end of name (before extension)
         r'_L\.',
         r'[_-]LN[_-]',
+        r'_LN\.',  # _LN at end of name (before extension)
         r'_low_',
         r'-low-',
         r'_low\.',


### PR DESCRIPTION
Handles filenames like:
- W22_Multiscene_Photoshoot_Softcore_i2v_HN.safetensors
- W22_Multiscene_Photoshoot_Softcore_i2v_LN.safetensors

Where _HN/_LN appear at end of name before extension.