### PR TITLE
Rework LoRA library UI from table to card grid

### DIFF
--- a/react-app/src/pages/LoraLibrary.css
+++ b/react-app/src/pages/LoraLibrary.css
@@ -3,67 +3,170 @@
 .lora-library {
   padding: 24px;
   max-width: 100%;
-  overflow-x: hidden;
 }
 
-.lora-library table {
-  width: 100%;
-  table-layout: fixed;
-  border-collapse: collapse;
+.lora-library h1 {
+  margin: 0;
+}
+
+.lora-library-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.lora-count {
+  color: #666;
+  font-size: 14px;
+}
+
+.lora-empty {
   background: white;
+  border-radius: 12px;
+  padding: 60px 40px;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.lora-library table th {
-  text-align: left;
+.lora-empty p {
+  color: #666;
+  margin: 8px 0;
+}
+
+/* Card grid - responsive 2-4 columns */
+.lora-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+
+@media (max-width: 1400px) {
+  .lora-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 1100px) {
+  .lora-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 700px) {
+  .lora-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Individual card */
+.lora-card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.lora-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+/* Preview image area */
+.lora-card-preview {
+  width: 100%;
+  aspect-ratio: 1;
+  background: #f5f5f5;
+  position: relative;
+  overflow: hidden;
+}
+
+.lora-card-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.lora-card-no-preview {
+  display: none;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 14px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* Card content */
+.lora-card-content {
   padding: 12px;
-  border-bottom: 2px solid #e0e0e0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lora-card-name {
   font-weight: 600;
+  font-size: 14px;
   color: #333;
+  line-height: 1.3;
+  /* Limit to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.lora-library table td {
-  padding: 12px;
-  border-bottom: 1px solid #f0f0f0;
+/* File tags */
+.lora-card-files {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.file-tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  word-wrap: break-word;
 }
 
-.lora-library table tbody tr:hover {
-  background: #f9f9f9;
+.file-tag.high {
+  background: #e8f5e9;
+  color: #2e7d32;
 }
 
-.lora-library table tbody tr:last-child td {
-  border-bottom: none;
+.file-tag.low {
+  background: #e3f2fd;
+  color: #1565c0;
 }
 
-/* Column widths */
-.lora-library table th:nth-child(1),
-.lora-library table td:nth-child(1) {
-  width: 20%;
+/* Keywords */
+.lora-card-keywords {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+  margin-top: 4px;
+  line-height: 1.3;
 }
 
-.lora-library table th:nth-child(2),
-.lora-library table td:nth-child(2) {
-  width: 30%;
-}
-
-.lora-library table th:nth-child(3),
-.lora-library table td:nth-child(3) {
-  width: 10%;
-}
-
-.lora-library table th:nth-child(4),
-.lora-library table td:nth-child(4) {
-  width: 8%;
-}
-
-.lora-library table th:nth-child(5),
-.lora-library table td:nth-child(5) {
-  width: 20%;
-}
-
-.lora-library table th:nth-child(6),
-.lora-library table td:nth-child(6) {
-  width: 12%;
+/* Actions */
+.lora-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 8px 12px;
+  border-top: 1px solid #f0f0f0;
+  background: #fafafa;
 }

--- a/react-app/src/pages/LoraLibrary.jsx
+++ b/react-app/src/pages/LoraLibrary.jsx
@@ -1,15 +1,12 @@
 import { useState, useEffect } from 'react';
-import { Button, Rating, CircularProgress } from '@mui/material';
+import { Button, Rating, CircularProgress, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import LinkIcon from '@mui/icons-material/Link';
 import API from '../api/client';
 import { showToast } from '../utils/helpers';
 import LoraEditModal from '../components/LoraEditModal';
 import './LoraLibrary.css';
-
-// Clean up base_name by removing {TYPE} placeholder
-function cleanBaseName(baseName) {
-  if (!baseName) return '';
-  return baseName.replace(/\{type\}/gi, '').replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
-}
 
 export default function LoraLibrary() {
   const [loras, setLoras] = useState([]);
@@ -32,7 +29,8 @@ export default function LoraLibrary() {
     }
   }
 
-  async function handleDelete(loraId, loraName) {
+  async function handleDelete(e, loraId, loraName) {
+    e.stopPropagation();
     if (!confirm(`Are you sure you want to delete "${loraName}" from the library?`)) {
       return;
     }
@@ -62,7 +60,7 @@ export default function LoraLibrary() {
 
   if (loading) {
     return (
-      <div>
+      <div className="lora-library">
         <h1>LoRA Library</h1>
         <div style={{ display: 'flex', justifyContent: 'center', padding: '40px' }}>
           <CircularProgress />
@@ -73,118 +71,97 @@ export default function LoraLibrary() {
 
   return (
     <div className="lora-library">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
-        <h1 style={{ margin: 0 }}>LoRA Library</h1>
-        <p style={{ color: '#666' }}>{loras.length} LoRA{loras.length !== 1 ? 's' : ''} cached</p>
+      <div className="lora-library-header">
+        <h1>LoRA Library</h1>
+        <span className="lora-count">{loras.length} LoRA{loras.length !== 1 ? 's' : ''}</span>
       </div>
 
       {loras.length === 0 ? (
-        <div className="card" style={{ padding: '40px', textAlign: 'center' }}>
-          <p style={{ color: '#999', margin: '0 0 16px 0' }}>
-            No LoRAs cached yet. Go to Settings and click "Fetch LoRAs from ComfyUI" to populate the library.
-          </p>
+        <div className="lora-empty">
+          <p>No LoRAs cached yet.</p>
+          <p>Go to Settings and click "Fetch LoRAs from ComfyUI" to populate the library.</p>
         </div>
       ) : (
-        <div className="card">
-          <table>
-            <thead>
-              <tr>
-                <th style={{ width: '70px' }}>Preview</th>
-                <th>Name</th>
-                <th>Rating</th>
-                <th>URL</th>
-                <th>Trigger Keywords</th>
-                <th style={{ width: '80px' }}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {loras.map((lora) => (
-                <tr key={lora.id} onClick={() => handleEdit(lora)} style={{ cursor: 'pointer' }}>
-                  <td style={{ padding: '4px' }}>
-                    <img
-                      src={API.getLoraPreviewUrl(lora.id)}
-                      alt="Preview"
-                      style={{
-                        width: '60px',
-                        height: '60px',
-                        objectFit: 'cover',
-                        borderRadius: '4px',
-                        backgroundColor: '#f0f0f0'
-                      }}
-                      onError={(e) => {
-                        e.target.style.display = 'none';
-                        e.target.nextSibling.style.display = 'flex';
-                      }}
-                    />
-                    <div style={{
-                      width: '60px',
-                      height: '60px',
-                      backgroundColor: '#f0f0f0',
-                      borderRadius: '4px',
-                      display: 'none',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      color: '#999',
-                      fontSize: '10px'
-                    }}>
-                      No preview
-                    </div>
-                  </td>
-                  <td>
-                    <div>
-                      {lora.friendly_name ? (
-                        <strong>{lora.friendly_name}</strong>
-                      ) : (
-                        <span style={{ color: '#999', fontStyle: 'italic' }}>—</span>
-                      )}
-                    </div>
-                    <div style={{ fontSize: '11px', marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '1px' }}>
-                      {lora.high_file && (
-                        <span style={{ color: '#2e7d32' }} title={lora.high_file}>
-                          H: {lora.high_file.split('/').pop()}
-                        </span>
-                      )}
-                      {lora.low_file && (
-                        <span style={{ color: '#1565c0' }} title={lora.low_file}>
-                          L: {lora.low_file.split('/').pop()}
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td>
-                    <Rating value={lora.rating || 0} readOnly size="small" />
-                  </td>
-                  <td>
-                    {lora.url ? (
-                      <a href={lora.url} target="_blank" rel="noopener noreferrer" style={{ fontSize: '13px' }}>
-                        Link
-                      </a>
-                    ) : (
-                      <span style={{ color: '#999' }}>—</span>
-                    )}
-                  </td>
-                  <td>
-                    {lora.trigger_keywords ? (
-                      <span style={{ fontSize: '13px' }}>{lora.trigger_keywords}</span>
-                    ) : (
-                      <span style={{ color: '#999' }}>—</span>
-                    )}
-                  </td>
-                  <td onClick={(e) => e.stopPropagation()}>
-                    <div style={{ display: 'flex', gap: '4px' }}>
-                      <button
-                        className="btn-icon delete"
-                        onClick={() => handleDelete(lora.id, lora.friendly_name || lora.high_file?.split('/').pop() || 'this LoRA')}
-                        title="Delete from library"
-                      >
-                        🗑️
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="lora-grid">
+          {loras.map((lora) => (
+            <div key={lora.id} className="lora-card" onClick={() => handleEdit(lora)}>
+              <div className="lora-card-preview">
+                <img
+                  src={API.getLoraPreviewUrl(lora.id)}
+                  alt="Preview"
+                  onError={(e) => {
+                    e.target.style.display = 'none';
+                    e.target.nextSibling.style.display = 'flex';
+                  }}
+                />
+                <div className="lora-card-no-preview">
+                  No preview
+                </div>
+              </div>
+
+              <div className="lora-card-content">
+                <div className="lora-card-name">
+                  {lora.friendly_name || lora.base_name?.replace(/\{type\}/gi, '').replace(/[_-]+/g, ' ').trim() || 'Unnamed'}
+                </div>
+
+                <Rating value={lora.rating || 0} readOnly size="small" />
+
+                <div className="lora-card-files">
+                  {lora.high_file && (
+                    <span className="file-tag high" title={lora.high_file}>
+                      H: {lora.high_file.split('/').pop().substring(0, 25)}...
+                    </span>
+                  )}
+                  {lora.low_file && (
+                    <span className="file-tag low" title={lora.low_file}>
+                      L: {lora.low_file.split('/').pop().substring(0, 25)}...
+                    </span>
+                  )}
+                </div>
+
+                {lora.trigger_keywords && (
+                  <div className="lora-card-keywords" title={lora.trigger_keywords}>
+                    {lora.trigger_keywords.length > 50
+                      ? lora.trigger_keywords.substring(0, 50) + '...'
+                      : lora.trigger_keywords}
+                  </div>
+                )}
+              </div>
+
+              <div className="lora-card-actions">
+                {lora.url && (
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      window.open(lora.url, '_blank');
+                    }}
+                    title="Open CivitAI page"
+                  >
+                    <LinkIcon fontSize="small" />
+                  </IconButton>
+                )}
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleEdit(lora);
+                  }}
+                  title="Edit"
+                >
+                  <EditIcon fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  onClick={(e) => handleDelete(e, lora.id, lora.friendly_name || lora.high_file?.split('/').pop() || 'this LoRA')}
+                  title="Delete"
+                  color="error"
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </div>
+            </div>
+          ))}
         </div>
       )}
 


### PR DESCRIPTION
- Replace table with responsive card grid (2-4 cards per row)
- Each card shows: preview image, name, rating, file tags, keywords
- Cards have hover effect and click to edit
- Action buttons: link to CivitAI, edit, delete
- Responsive breakpoints: 4 cols > 1400px, 3 cols > 1100px, 2 cols > 700px