### PR TITLE
Fix: Lock dimensions/fps on failed jobs with completed segments

### DIFF
--- a/react-app/src/components/EditJobModal.jsx
+++ b/react-app/src/components/EditJobModal.jsx
@@ -8,11 +8,11 @@ export default function EditJobModal({ job, onClose, onSuccess }) {
   const params = job.parameters || {};
 
   // Check if job has active completed segments (not deleted)
-  // Allow editing if: no segments completed, all segments deleted, or job failed
+  // Dimensions/fps are locked once any segment is completed (to prevent resolution mismatch during stitching)
   const completedSegments = job.completed_segments ?? 0;
   const deletedSegments = job.deleted_segments ?? 0;
   const activeCompletedSegments = completedSegments - deletedSegments;
-  const hasStarted = activeCompletedSegments > 0 && job.status !== 'failed';
+  const hasStarted = activeCompletedSegments > 0;
 
   const [name, setName] = useState(job.name || '');
   const [prompt, setPrompt] = useState(job.prompt || '');


### PR DESCRIPTION
Previously, the hasStarted check allowed editing dimensions when a job was in 'failed' status, even if it had completed segments. This could cause resolution mismatches when retrying or finalizing, breaking ffmpeg concat which requires all segments to have identical dimensions.

Now dimensions/fps are locked whenever there are active (non-deleted) completed segments, regardless of job status.