### PR TITLE
Add server-side status filtering to jobs API

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -746,14 +746,27 @@ def get_job(job_id: int) -> Optional[Dict[str, Any]]:
         return None
 
 
-def get_all_jobs(limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
-    """Get all jobs with pagination."""
+def get_all_jobs(limit: int = 100, offset: int = 0, statuses: List[str] = None) -> List[Dict[str, Any]]:
+    """Get all jobs with pagination and optional status filtering.
+
+    Args:
+        limit: Maximum number of jobs to return
+        offset: Number of jobs to skip
+        statuses: Optional list of statuses to filter by (e.g., ['pending', 'running'])
+    """
     with get_connection() as conn:
         cursor = conn.cursor()
-        cursor.execute(
-            "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ? OFFSET ?",
-            (limit, offset)
-        )
+        if statuses:
+            placeholders = ','.join('?' * len(statuses))
+            cursor.execute(
+                f"SELECT * FROM jobs WHERE status IN ({placeholders}) ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                (*statuses, limit, offset)
+            )
+        else:
+            cursor.execute(
+                "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                (limit, offset)
+            )
         return [_row_to_job_dict(row) for row in cursor.fetchall()]
 
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,6 +1,6 @@
 """API routes for the ComfyUI Queue Manager."""
 
-from fastapi import APIRouter, HTTPException, UploadFile, File, Form, BackgroundTasks
+from fastapi import APIRouter, HTTPException, UploadFile, File, Form, BackgroundTasks, Query
 from fastapi.responses import RedirectResponse, FileResponse, Response
 from pydantic import BaseModel
 from typing import Optional, Dict, Any, List
@@ -381,8 +381,17 @@ class QueueStatus(BaseModel):
 # ============== Job Endpoints ==============
 
 @router.get("/jobs")
-async def list_jobs(limit: int = 100, offset: int = 0):
-    """Get all jobs with pagination, enriched with segment counts and queue info.
+async def list_jobs(
+    limit: int = 100,
+    offset: int = 0,
+    status: Optional[str] = Query(None, description="Comma-separated list of statuses to filter by")
+):
+    """Get all jobs with pagination and optional status filtering.
+
+    Args:
+        limit: Maximum number of jobs to return (default 100)
+        offset: Number of jobs to skip for pagination
+        status: Comma-separated list of statuses (e.g., 'pending,running,awaiting_prompt')
 
     Returns:
         Object with jobs list, avg_run_time, and queue position info.
@@ -390,7 +399,8 @@ async def list_jobs(limit: int = 100, offset: int = 0):
         - queue_position: Position in queue (1-based) for pending jobs, null otherwise
         - estimated_wait_seconds: Estimated wait time based on queue position × avg_run_time
     """
-    jobs = get_all_jobs(limit=limit, offset=offset)
+    statuses = [s.strip() for s in status.split(',')] if status else None
+    jobs = get_all_jobs(limit=limit, offset=offset, statuses=statuses)
     enriched_jobs = [enrich_job_with_segments(job) for job in jobs]
     avg_time = get_avg_run_time(num_segments=5)
 

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -74,8 +74,12 @@ class APIClient {
 
   // ============== Jobs ==============
 
-  async getJobs(limit = 100, offset = 0) {
-    return this.request(`/jobs?limit=${limit}&offset=${offset}`);
+  async getJobs(limit = 100, offset = 0, statuses = null) {
+    let url = `/jobs?limit=${limit}&offset=${offset}`;
+    if (statuses && statuses.length > 0) {
+      url += `&status=${statuses.join(',')}`;
+    }
+    return this.request(url);
   }
 
   async getJob(jobId) {

--- a/react-app/src/contexts/JobsContext.jsx
+++ b/react-app/src/contexts/JobsContext.jsx
@@ -33,7 +33,7 @@ export function JobsProvider({ children }) {
   const fetchJobs = useCallback(async () => {
     try {
       const [jobsData, comfy] = await Promise.all([
-        API.getJobs(),
+        API.getJobs(10000), // Fetch all jobs for accurate stats
         API.checkComfyStatus()
       ]);
 


### PR DESCRIPTION
- Add statuses parameter to get_all_jobs() for SQL-level filtering
- Add status query parameter to /api/jobs endpoint (comma-separated)
- Update API client to support status filtering
- Increase default fetch limit in JobsContext for accurate stats

This fixes the issue where jobs beyond the 100-job limit weren't visible when filtering by status (e.g., running, awaiting_prompt).