### PR TITLE
Fix timestamps displaying as UTC instead of local time

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1475,12 +1475,12 @@ def create_first_segment(
         cursor.execute("""
             INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora,
                                       faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index,
-                                      faceswap_source_image, faceswap_params, fade_to_black)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                      faceswap_source_image, faceswap_params, fade_to_black, created_at)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, 0, initial_prompt, start_image_url,
               serialize_loras(high_loras), serialize_loras(low_loras),
               1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index,
-              faceswap_source_image, faceswap_params, 1 if fade_to_black else 0))
+              faceswap_source_image, faceswap_params, 1 if fade_to_black else 0, utc_now_iso()))
 
 
 def create_next_segment(
@@ -1562,12 +1562,12 @@ def create_next_segment(
         cursor.execute("""
             INSERT INTO job_segments (job_id, segment_index, status, prompt, prompt_template, start_image_url, high_lora, low_lora,
                                       faceswap_enabled, faceswap_image, faceswap_faces_order, faceswap_faces_index,
-                                      faceswap_source_image, faceswap_params, fade_to_black, custom_start_image)
-            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                      faceswap_source_image, faceswap_params, fade_to_black, custom_start_image, created_at)
+            VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (job_id, segment_index, prompt, template, start_image_url,
               serialize_loras(high_loras), serialize_loras(low_loras),
               1 if faceswap_enabled else 0, faceswap_image, faceswap_faces_order, faceswap_faces_index,
-              faceswap_source_image, faceswap_params, 1 if fade_to_black else 0, custom_start_image))
+              faceswap_source_image, faceswap_params, 1 if fade_to_black else 0, custom_start_image, utc_now_iso()))
 
 
 def create_segments_for_job(
@@ -1593,20 +1593,21 @@ def create_segments_for_job(
     """
     with get_connection() as conn:
         cursor = conn.cursor()
+        now = utc_now_iso()
         for i in range(total_segments):
             if i == 0:
                 # First segment uses the uploaded image, initial prompt, and LoRA selections
                 cursor.execute("""
-                    INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora)
-                    VALUES (?, ?, 'pending', ?, ?, ?, ?)
+                    INSERT INTO job_segments (job_id, segment_index, status, prompt, start_image_url, high_lora, low_lora, created_at)
+                    VALUES (?, ?, 'pending', ?, ?, ?, ?, ?)
                 """, (job_id, i, initial_prompt, start_image_url,
-                      serialize_loras(high_loras), serialize_loras(low_loras)))
+                      serialize_loras(high_loras), serialize_loras(low_loras), now))
             else:
                 # Subsequent segments start with no prompt - user provides after previous segment completes
                 cursor.execute("""
-                    INSERT INTO job_segments (job_id, segment_index, status)
-                    VALUES (?, ?, 'pending')
-                """, (job_id, i))
+                    INSERT INTO job_segments (job_id, segment_index, status, created_at)
+                    VALUES (?, ?, 'pending', ?)
+                """, (job_id, i, now))
 
 
 def get_job_segments(job_id: int) -> List[Dict[str, Any]]:

--- a/react-app/src/components/ImagePreviewModal.jsx
+++ b/react-app/src/components/ImagePreviewModal.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Button, Rating, Box, Typography, CircularProgress, FormControl, InputLabel, Select, MenuItem, Chip } from '@mui/material';
 import { Link } from 'react-router-dom';
 import API from '../api/client';
-import { showToast } from '../utils/helpers';
+import { showToast, normalizeUtcTimestamp } from '../utils/helpers';
 import './CreateJobModal.css';
 
 export default function ImagePreviewModal({ image, images, currentIndex, onClose, onCreateJob, onDelete, onNavigate, onRatingChange }) {
@@ -555,7 +555,7 @@ export default function ImagePreviewModal({ image, images, currentIndex, onClose
                         padding: '4px 8px'
                       }}
                     >
-                      VR #{vr.id} - {new Date(vr.created_at).toLocaleDateString()}
+                      VR #{vr.id} - {new Date(normalizeUtcTimestamp(vr.created_at)).toLocaleDateString()}
                     </Button>
                   ))}
                 </div>

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -1614,7 +1614,7 @@ export default function JobDetail() {
                       return (
                         <tr key={log.id} style={{ borderBottom: '1px solid #eee' }}>
                           <td style={{ padding: '8px', fontFamily: 'monospace', fontSize: '12px', color: '#666' }}>
-                            {new Date(log.timestamp).toLocaleString()}
+                            {formatDate(log.timestamp)}
                           </td>
                           <td style={{ padding: '8px' }}>
                             <span style={{

--- a/react-app/src/utils/helpers.js
+++ b/react-app/src/utils/helpers.js
@@ -2,10 +2,34 @@
  * Utility helper functions
  */
 
+/**
+ * Normalize a timestamp string to ensure it's interpreted as UTC.
+ * SQLite CURRENT_TIMESTAMP produces "2024-01-15 10:30:00" (no timezone).
+ * Our utc_now_iso() produces "2024-01-15T10:30:00Z".
+ * Without 'Z', browsers interpret the timestamp as local time.
+ */
+export function normalizeUtcTimestamp(dateString) {
+  if (!dateString) return null;
+  // Already has timezone info (Z or +/-offset)
+  if (/[Z+-]\d{0,4}:?\d{0,2}$/.test(dateString)) {
+    return dateString;
+  }
+  // SQLite format "YYYY-MM-DD HH:MM:SS" - add Z to mark as UTC
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(dateString)) {
+    return dateString.replace(' ', 'T') + 'Z';
+  }
+  // ISO format without timezone "YYYY-MM-DDTHH:MM:SS" - add Z
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(dateString)) {
+    return dateString + 'Z';
+  }
+  return dateString;
+}
+
 export function formatDate(dateString) {
   if (!dateString) return 'N/A';
   try {
-    const date = new Date(dateString);
+    const normalized = normalizeUtcTimestamp(dateString);
+    const date = new Date(normalized);
     return date.toLocaleString();
   } catch {
     return dateString;
@@ -15,7 +39,8 @@ export function formatDate(dateString) {
 export function formatTime(isoString) {
   if (!isoString) return '--';
   try {
-    const date = new Date(isoString);
+    const normalized = normalizeUtcTimestamp(isoString);
+    const date = new Date(normalized);
     return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
   } catch {
     return '--';


### PR DESCRIPTION
Backend: Explicitly set created_at with utc_now_iso() for all segment inserts instead of relying on SQLite's CURRENT_TIMESTAMP default (which produces timestamps without timezone info).

Frontend: Add normalizeUtcTimestamp() helper that detects timestamps without timezone info and appends 'Z' suffix so JavaScript interprets them as UTC and converts properly to local time via toLocaleString().