### PR TITLE
Add local video server for faster playback

### DIFF
--- a/local-server/serve.py
+++ b/local-server/serve.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Local static file server for wan22-data directory.
+
+Serves files with CORS headers so the frontend can load videos/images locally
+instead of over the network. This dramatically improves playback for large videos.
+
+Usage:
+    python serve.py [--port PORT] [--data-dir PATH]
+
+Examples:
+    python serve.py                              # Serve ../wan22-data on port 8765
+    python serve.py --port 9000                  # Custom port
+    python serve.py --data-dir /path/to/data     # Custom data directory
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from functools import partial
+
+
+class CORSRequestHandler(SimpleHTTPRequestHandler):
+    """HTTP request handler with CORS headers for cross-origin requests."""
+
+    def __init__(self, *args, directory=None, **kwargs):
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def end_headers(self):
+        """Add CORS headers to all responses."""
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Range')
+        self.send_header('Access-Control-Expose-Headers', 'Content-Length, Content-Range')
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        """Handle CORS preflight requests."""
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        """Custom log format with color coding."""
+        status = args[1] if len(args) > 1 else ''
+        if status.startswith('2'):
+            color = '\033[92m'  # Green
+        elif status.startswith('3'):
+            color = '\033[93m'  # Yellow
+        elif status.startswith('4'):
+            color = '\033[91m'  # Red
+        else:
+            color = '\033[0m'   # Default
+
+        reset = '\033[0m'
+        print(f"{color}{self.address_string()} - {format % args}{reset}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Local static file server for wan22-data',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+URL mapping examples:
+  Local:  http://localhost:8765/job_output/job_1000/segment_0.webm
+  Local:  http://localhost:8765/thumbnail_cache/job_1000_thumb.jpg
+        """
+    )
+    parser.add_argument(
+        '--port', '-p',
+        type=int,
+        default=8765,
+        help='Port to serve on (default: 8765)'
+    )
+    parser.add_argument(
+        '--data-dir', '-d',
+        type=str,
+        default=None,
+        help='Path to wan22-data directory (default: ../wan22-data relative to script)'
+    )
+    parser.add_argument(
+        '--bind', '-b',
+        type=str,
+        default='0.0.0.0',
+        help='Address to bind to (default: 0.0.0.0)'
+    )
+
+    args = parser.parse_args()
+
+    # Determine data directory
+    if args.data_dir:
+        data_dir = Path(args.data_dir).resolve()
+    else:
+        # Default: look for wan22-data in common locations
+        script_dir = Path(__file__).parent.resolve()
+        possible_paths = [
+            script_dir.parent / 'wan22-data',           # ../wan22-data
+            Path.home() / 'projects' / 'wan22-data',    # ~/projects/wan22-data
+            Path('/home/david/projects/wan22-data'),    # Absolute fallback
+        ]
+
+        data_dir = None
+        for p in possible_paths:
+            if p.exists():
+                data_dir = p
+                break
+
+        if not data_dir:
+            print("Error: Could not find wan22-data directory.", file=sys.stderr)
+            print("Searched:", file=sys.stderr)
+            for p in possible_paths:
+                print(f"  - {p}", file=sys.stderr)
+            print("\nSpecify manually with --data-dir", file=sys.stderr)
+            sys.exit(1)
+
+    if not data_dir.exists():
+        print(f"Error: Data directory does not exist: {data_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create handler with the data directory
+    handler = partial(CORSRequestHandler, directory=str(data_dir))
+
+    # Start server
+    server = HTTPServer((args.bind, args.port), handler)
+
+    print(f"\n{'='*60}")
+    print(f"  Local Video Server")
+    print(f"{'='*60}")
+    print(f"  Serving:  {data_dir}")
+    print(f"  URL:      http://localhost:{args.port}")
+    print(f"  Binding:  {args.bind}:{args.port}")
+    print(f"{'='*60}")
+    print(f"\nAdd this URL to Settings > Local Server URL in the web UI")
+    print(f"Press Ctrl+C to stop\n")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        server.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/react-app/src/api/client.js
+++ b/react-app/src/api/client.js
@@ -8,6 +8,8 @@ class APIClient {
   constructor() {
     // Load custom API URL from localStorage if set
     this.baseUrl = localStorage.getItem('api_url') || DEFAULT_API_URL;
+    // Load local server URL for faster video/image loading
+    this.localServerUrl = localStorage.getItem('local_server_url') || '';
   }
 
   /**
@@ -29,6 +31,59 @@ class APIClient {
    */
   getBaseUrl() {
     return this.baseUrl;
+  }
+
+  /**
+   * Set a custom local server URL for faster video/image loading
+   * @param {string} url - The local server URL (e.g., 'http://localhost:8765')
+   */
+  setLocalServerUrl(url) {
+    if (url && url.trim()) {
+      this.localServerUrl = url.trim().replace(/\/$/, ''); // Remove trailing slash
+      localStorage.setItem('local_server_url', this.localServerUrl);
+    } else {
+      this.localServerUrl = '';
+      localStorage.removeItem('local_server_url');
+    }
+  }
+
+  /**
+   * Get the current local server URL
+   */
+  getLocalServerUrl() {
+    return this.localServerUrl;
+  }
+
+  /**
+   * Get local URL for a segment video (if local server is configured)
+   * @param {number} jobId - Job ID
+   * @param {number} segmentIndex - Segment index
+   * @returns {string|null} Local URL or null if not configured
+   */
+  getLocalSegmentVideo(jobId, segmentIndex) {
+    if (!this.localServerUrl) return null;
+    return `${this.localServerUrl}/job_output/job_${jobId}/segment_${segmentIndex}.webm`;
+  }
+
+  /**
+   * Get local URL for a job's final video (if local server is configured)
+   * @param {number} jobId - Job ID
+   * @param {string} filename - Video filename (from job data)
+   * @returns {string|null} Local URL or null if not configured
+   */
+  getLocalJobVideo(jobId, filename) {
+    if (!this.localServerUrl || !filename) return null;
+    return `${this.localServerUrl}/job_output/job_${jobId}/${filename}`;
+  }
+
+  /**
+   * Get local URL for a thumbnail (if local server is configured)
+   * @param {number} jobId - Job ID
+   * @returns {string|null} Local URL or null if not configured
+   */
+  getLocalThumbnail(jobId) {
+    if (!this.localServerUrl) return null;
+    return `${this.localServerUrl}/thumbnail_cache/job_${jobId}_thumb.jpg`;
   }
 
   async request(endpoint, options = {}) {

--- a/react-app/src/components/VideoPlayer.jsx
+++ b/react-app/src/components/VideoPlayer.jsx
@@ -1,0 +1,143 @@
+import { useState, useRef, useEffect } from 'react';
+import API from '../api/client';
+
+/**
+ * Video player component with local/remote fallback.
+ *
+ * Tries to load video from local server first (if configured),
+ * falls back to remote API on error.
+ *
+ * @param {Object} props
+ * @param {string} props.src - Remote video URL
+ * @param {string} props.localSrc - Local video URL (optional, will use API.getLocalServerUrl if available)
+ * @param {string} props.className - CSS class for the video element
+ * @param {Object} props.style - Inline styles
+ * @param {boolean} props.controls - Show video controls (default: true)
+ * @param {boolean} props.autoPlay - Auto-play video (default: false)
+ * @param {boolean} props.loop - Loop video (default: false)
+ * @param {boolean} props.muted - Mute video (default: false)
+ * @param {string} props.poster - Poster image URL
+ * @param {function} props.onLoadedData - Callback when video data is loaded
+ * @param {function} props.onError - Callback on error (after all fallbacks exhausted)
+ */
+export default function VideoPlayer({
+  src,
+  localSrc,
+  className,
+  style,
+  controls = true,
+  autoPlay = false,
+  loop = false,
+  muted = false,
+  poster,
+  onLoadedData,
+  onError,
+  ...rest
+}) {
+  const [currentSrc, setCurrentSrc] = useState(null);
+  const [isLocal, setIsLocal] = useState(false);
+  const [triedLocal, setTriedLocal] = useState(false);
+  const videoRef = useRef(null);
+
+  // Determine initial source
+  useEffect(() => {
+    const localUrl = localSrc || null;
+
+    if (localUrl && !triedLocal) {
+      // Try local first
+      setCurrentSrc(localUrl);
+      setIsLocal(true);
+    } else {
+      // Use remote
+      setCurrentSrc(src);
+      setIsLocal(false);
+    }
+  }, [src, localSrc, triedLocal]);
+
+  const handleError = () => {
+    if (isLocal && !triedLocal) {
+      // Local failed, fall back to remote
+      console.log('[VideoPlayer] Local source failed, falling back to remote:', src);
+      setTriedLocal(true);
+      setCurrentSrc(src);
+      setIsLocal(false);
+    } else if (onError) {
+      // Remote also failed
+      onError();
+    }
+  };
+
+  const handleLoadedData = (e) => {
+    if (isLocal) {
+      console.log('[VideoPlayer] Loaded from local server');
+    }
+    if (onLoadedData) {
+      onLoadedData(e);
+    }
+  };
+
+  if (!currentSrc) return null;
+
+  return (
+    <video
+      ref={videoRef}
+      src={currentSrc}
+      className={className}
+      style={style}
+      controls={controls}
+      autoPlay={autoPlay}
+      loop={loop}
+      muted={muted}
+      poster={poster}
+      onError={handleError}
+      onLoadedData={handleLoadedData}
+      {...rest}
+    />
+  );
+}
+
+/**
+ * Segment video player with automatic local/remote handling.
+ *
+ * @param {Object} props
+ * @param {number} props.jobId - Job ID
+ * @param {number} props.segmentIndex - Segment index
+ * @param {string} props.className - CSS class
+ * @param {Object} props.style - Inline styles
+ * @param {boolean} props.controls - Show controls (default: true)
+ */
+export function SegmentVideoPlayer({ jobId, segmentIndex, ...rest }) {
+  const remoteSrc = API.getSegmentVideo(jobId, segmentIndex);
+  const localSrc = API.getLocalSegmentVideo(jobId, segmentIndex);
+
+  return (
+    <VideoPlayer
+      src={remoteSrc}
+      localSrc={localSrc}
+      {...rest}
+    />
+  );
+}
+
+/**
+ * Job video player (final merged video) with automatic local/remote handling.
+ *
+ * @param {Object} props
+ * @param {number} props.jobId - Job ID
+ * @param {string} props.filename - Video filename (optional, for local lookup)
+ * @param {string} props.className - CSS class
+ * @param {Object} props.style - Inline styles
+ * @param {boolean} props.controls - Show controls (default: true)
+ */
+export function JobVideoPlayer({ jobId, filename, ...rest }) {
+  const remoteSrc = API.getJobVideo(jobId);
+  const localSrc = API.getLocalJobVideo(jobId, filename);
+
+  return (
+    <VideoPlayer
+      src={remoteSrc}
+      localSrc={localSrc}
+      {...rest}
+    />
+  );
+}

--- a/react-app/src/pages/JobDetail.jsx
+++ b/react-app/src/pages/JobDetail.jsx
@@ -19,6 +19,7 @@ import LoraEditModal from '../components/LoraEditModal';
 import SegmentNotesModal from '../components/SegmentNotesModal';
 import MergeConfigModal from '../components/MergeConfigModal';
 import StatusChip from '../components/StatusChip';
+import { JobVideoPlayer, SegmentVideoPlayer } from '../components/VideoPlayer';
 import './JobDetail.css';
 
 // Helper functions moved to module level for memoization
@@ -772,14 +773,13 @@ export default function JobDetail() {
           <div style={{ display: 'flex', gap: '24px', flexWrap: 'wrap' }}>
             {/* Left side: Video and buttons */}
             <div style={{ flex: '0 0 auto' }}>
-              <video
+              <JobVideoPlayer
                 key={`video-${id}-${job.completed_at}`}
+                jobId={id}
+                filename={job.output_images?.[0]}
                 controls
                 style={{ width: '100%', maxWidth: width >= height ? '500px' : '300px', borderRadius: '4px' }}
-                src={API.getJobVideo(id)}
-              >
-                Your browser does not support video playback.
-              </video>
+              />
               <div style={{ marginTop: '12px', display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
                 <Button
                   variant="contained"
@@ -1853,8 +1853,10 @@ export default function JobDetail() {
             onClick={(e) => e.stopPropagation()}
             style={{ maxWidth: '800px' }}
           >
-            <video
-              src={`${API.getSegmentVideo(id, segmentVideoIndex)}?t=${segmentVideoKey}`}
+            <SegmentVideoPlayer
+              key={`seg-${segmentVideoIndex}-${segmentVideoKey}`}
+              jobId={id}
+              segmentIndex={segmentVideoIndex}
               controls
               autoPlay
               playsInline

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -17,6 +17,7 @@ export default function Settings() {
 
   // Form fields
   const [apiUrl, setApiUrl] = useState('');
+  const [localServerUrl, setLocalServerUrl] = useState('');
   const [comfyuiUrl, setComfyuiUrl] = useState('');
   const [imageRepoPath, setImageRepoPath] = useState('');
   // ComfyUI model settings
@@ -80,8 +81,9 @@ export default function Settings() {
       const s = data.settings || data;
       setSettings(s);
 
-      // api_url is client-side only, stored in localStorage via API client
+      // api_url and local_server_url are client-side only, stored in localStorage via API client
       setApiUrl(API.getBaseUrl() === '/api' ? '' : API.getBaseUrl());
+      setLocalServerUrl(API.getLocalServerUrl() || '');
       setComfyuiUrl(s.comfyui_url || 'http://localhost:8188');
       setImageRepoPath(s.image_repo_path || '');
       // ComfyUI model settings
@@ -252,8 +254,9 @@ export default function Settings() {
 
       await API.updateSettings(settingsPayload);
 
-      // Update client-side API URL after successful save
+      // Update client-side settings after successful save
       API.setBaseUrl(apiUrl);
+      API.setLocalServerUrl(localServerUrl);
 
       showToast('Settings saved successfully', 'success');
       setSaving(false);
@@ -438,6 +441,33 @@ export default function Settings() {
             </div>
             <small style={{ color: '#666', fontSize: '12px' }}>
               Backend API URL (e.g., http://2070.zero:9090/api). Click "Apply & Reload" to save and refresh.
+            </small>
+          </div>
+
+          <div className="form-group" style={{ marginTop: '16px' }}>
+            <label>Local Video Server URL</label>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <input
+                type="text"
+                value={localServerUrl}
+                onChange={(e) => setLocalServerUrl(e.target.value)}
+                placeholder="e.g., http://localhost:8765"
+                style={{ flex: 1 }}
+              />
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => {
+                  API.setLocalServerUrl(localServerUrl);
+                  showToast(localServerUrl ? 'Local server URL saved' : 'Local server URL cleared', 'success');
+                }}
+              >
+                Apply
+              </Button>
+            </div>
+            <small style={{ color: '#666', fontSize: '12px' }}>
+              Optional: URL of local server serving synced videos (e.g., from rsync).
+              Run <code>python local-server/serve.py</code> to start. Videos load from local first, fall back to remote.
             </small>
           </div>
         </div>


### PR DESCRIPTION
Local server (local-server/serve.py):
- Python static file server with CORS headers
- Serves files from wan22-data directory (rsync'd mirror)
- Configurable port (default 8765) and data directory

Frontend changes:
- Add local_server_url client-side setting (stored in localStorage)
- New VideoPlayer component with local/remote fallback
- SegmentVideoPlayer and JobVideoPlayer specialized components
- Settings UI for configuring local server URL
- JobDetail uses new video components

Usage:
1. Run rsync to mirror videos locally
2. Start local server: python local-server/serve.py
3. Set Local Video Server URL in Settings (e.g., http://localhost:8765)
4. Videos load from local first, fall back to remote on error