### PR TITLE
Remove local server start/stop controls from Settings

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -3447,82 +3447,9 @@ async def delete_vr_video_endpoint(vr_video_id: int):
     return {"deleted": True, "file_deleted": file_deleted}
 
 
-# ============== Local Server & Sync Endpoints ==============
+# ============== Sync Endpoints ==============
 
-LOCAL_SERVER_TMUX_SESSION = "local-video-server"
-LOCAL_SERVER_SCRIPT = Path(__file__).parent.parent / "local-server" / "serve.py"
 SYNC_SCRIPT = Path.home() / "projects" / "scripts" / "sync.sh"
-
-
-@router.get("/local-server/status")
-async def get_local_server_status():
-    """Check if local video server tmux session is running."""
-    try:
-        result = subprocess.run(
-            ["tmux", "has-session", "-t", LOCAL_SERVER_TMUX_SESSION],
-            capture_output=True,
-            text=True
-        )
-        running = result.returncode == 0
-        return {"running": running, "session_name": LOCAL_SERVER_TMUX_SESSION}
-    except FileNotFoundError:
-        return {"running": False, "error": "tmux not installed"}
-    except Exception as e:
-        return {"running": False, "error": str(e)}
-
-
-@router.post("/local-server/start")
-async def start_local_server():
-    """Start the local video server in a tmux session."""
-    # Check if already running
-    try:
-        result = subprocess.run(
-            ["tmux", "has-session", "-t", LOCAL_SERVER_TMUX_SESSION],
-            capture_output=True,
-            text=True
-        )
-        if result.returncode == 0:
-            return {"success": False, "error": "Local server is already running"}
-    except FileNotFoundError:
-        raise HTTPException(status_code=500, detail="tmux not installed")
-
-    # Check if script exists
-    if not LOCAL_SERVER_SCRIPT.exists():
-        raise HTTPException(status_code=500, detail=f"Local server script not found: {LOCAL_SERVER_SCRIPT}")
-
-    # Start in tmux session
-    try:
-        cmd = f"python {LOCAL_SERVER_SCRIPT}"
-        result = subprocess.run(
-            ["tmux", "new-session", "-d", "-s", LOCAL_SERVER_TMUX_SESSION, cmd],
-            capture_output=True,
-            text=True
-        )
-        if result.returncode != 0:
-            raise HTTPException(status_code=500, detail=f"Failed to start tmux session: {result.stderr}")
-
-        return {"success": True, "message": f"Local server started in tmux session '{LOCAL_SERVER_TMUX_SESSION}'"}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@router.post("/local-server/stop")
-async def stop_local_server():
-    """Stop the local video server tmux session."""
-    try:
-        result = subprocess.run(
-            ["tmux", "kill-session", "-t", LOCAL_SERVER_TMUX_SESSION],
-            capture_output=True,
-            text=True
-        )
-        if result.returncode != 0:
-            return {"success": False, "error": "Session not found or already stopped"}
-
-        return {"success": True, "message": "Local server stopped"}
-    except FileNotFoundError:
-        raise HTTPException(status_code=500, detail="tmux not installed")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/sync/run")

--- a/react-app/src/pages/Settings.jsx
+++ b/react-app/src/pages/Settings.jsx
@@ -54,9 +54,7 @@ export default function Settings() {
   const [facefusionDetectorModel, setFacefusionDetectorModel] = useState('retinaface');
   const [facefusionReferenceDistance, setFacefusionReferenceDistance] = useState(0.8);
 
-  // Local server & sync state
-  const [localServerRunning, setLocalServerRunning] = useState(false);
-  const [localServerLoading, setLocalServerLoading] = useState(false);
+  // Sync state
   const [syncRunning, setSyncRunning] = useState(false);
   const [syncOutput, setSyncOutput] = useState('');
 
@@ -79,49 +77,7 @@ export default function Settings() {
   useEffect(() => {
     loadSettings();
     loadHiddenLoras();
-    checkLocalServerStatus();
   }, []);
-
-  async function checkLocalServerStatus() {
-    try {
-      const status = await API.request('/local-server/status');
-      setLocalServerRunning(status.running);
-    } catch (error) {
-      console.error('Failed to check local server status:', error);
-    }
-  }
-
-  async function handleStartLocalServer() {
-    setLocalServerLoading(true);
-    try {
-      const result = await API.request('/local-server/start', { method: 'POST' });
-      if (result.success) {
-        showToast('Local server started', 'success');
-        setLocalServerRunning(true);
-      } else {
-        showToast(result.error || 'Failed to start', 'error');
-      }
-    } catch (error) {
-      showToast(error.message || 'Failed to start local server', 'error');
-    }
-    setLocalServerLoading(false);
-  }
-
-  async function handleStopLocalServer() {
-    setLocalServerLoading(true);
-    try {
-      const result = await API.request('/local-server/stop', { method: 'POST' });
-      if (result.success) {
-        showToast('Local server stopped', 'success');
-        setLocalServerRunning(false);
-      } else {
-        showToast(result.error || 'Failed to stop', 'error');
-      }
-    } catch (error) {
-      showToast(error.message || 'Failed to stop local server', 'error');
-    }
-    setLocalServerLoading(false);
-  }
 
   async function handleRunSync() {
     setSyncRunning(true);
@@ -534,51 +490,6 @@ export default function Settings() {
             <small style={{ color: '#666', fontSize: '12px' }}>
               Optional: URL of local server serving synced videos (e.g., from rsync).
               Videos load from local first, fall back to remote.
-            </small>
-          </div>
-
-          <div style={{ marginTop: '20px', paddingTop: '16px', borderTop: '1px solid #333' }}>
-            <h3 style={{ fontSize: '14px', marginBottom: '12px' }}>Local Server Control</h3>
-            <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-              <div style={{
-                width: '12px',
-                height: '12px',
-                borderRadius: '50%',
-                backgroundColor: localServerRunning ? '#4caf50' : '#f44336'
-              }} />
-              <span style={{ color: '#666', fontSize: '14px' }}>
-                {localServerRunning ? 'Running' : 'Stopped'}
-              </span>
-              {localServerRunning ? (
-                <Button
-                  variant="outlined"
-                  size="small"
-                  color="error"
-                  onClick={handleStopLocalServer}
-                  disabled={localServerLoading}
-                >
-                  {localServerLoading ? 'Stopping...' : 'Stop Server'}
-                </Button>
-              ) : (
-                <Button
-                  variant="contained"
-                  size="small"
-                  onClick={handleStartLocalServer}
-                  disabled={localServerLoading}
-                >
-                  {localServerLoading ? 'Starting...' : 'Start Server'}
-                </Button>
-              )}
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={checkLocalServerStatus}
-              >
-                Refresh
-              </Button>
-            </div>
-            <small style={{ color: '#666', fontSize: '12px', marginTop: '8px', display: 'block' }}>
-              Starts/stops the local video server in a tmux session.
             </small>
           </div>
 


### PR DESCRIPTION
The local server (serve.py) runs on the user's local machine, not on 2070.zero where the backend API runs. Managing it via the API was incorrect - the tmux session would be created on 2070.zero instead of locally.

Users should start the local server manually:
  cd local-server && python serve.py

Removed:
- Backend endpoints: /local-server/status, /start, /stop
- Settings UI: Local Server Control section with status indicator and buttons